### PR TITLE
Freeze v0.1 naming: snake_case JSON + kebab-case CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,21 +10,26 @@ v0.1 is intentionally small. It ships three primitives:
 
 No UI in v0.1.
 
-## CLI surface (proposed)
+## Naming/shape freeze (v0.1)
+
+- JSON fields (events, receipts, config): **snake_case**
+- CLI flags: **kebab-case** (mapped to snake_case fields)
+
+## CLI surface (frozen)
 
 - `team-relay serve`
   - starts HTTP server for inbound webhooks
-  - writes normalized tasks to queue
+  - appends normalized events to the queue file
 
-- `team-relay tmux run --session <name> --cmd "..." [--cwd <path>] [--timeout <sec>]`
-  - runs command inside tmux
-  - captures last N lines + exit code
-  - emits a receipt
+- `team-relay tmux run --session <name> --cmd "..." [--cwd <path>] [--timeout-sec <sec>]`
+  - runs an allowlisted command inside the tmux session
+  - captures last N lines of stdout/stderr + exit code
+  - appends a receipt
 
 - `team-relay emit --to <url> --json <file>`
-  - send a receipt or event to a webhook target
+  - sends a receipt or event JSON to a webhook target
 
-- `team-relay receipt tail [--n 1]`
+- `team-relay receipt tail [--n <count>]`
   - prints the last receipt(s) as JSON
 
 ## Schemas

--- a/config/team-relay.example.json
+++ b/config/team-relay.example.json
@@ -8,10 +8,10 @@
   },
   "receipts": {
     "path": "./team-relay-receipts.jsonl",
-    "stdoutTailLines": 80
+    "stdout_tail_lines": 80
   },
   "tmux": {
-    "defaultSession": "ide-agent",
+    "default_session": "ide-agent",
     "allow": [
       "pytest",
       "npm test",
@@ -20,8 +20,8 @@
     ]
   },
   "github": {
-    "webhookSecret": "CHANGE_ME",
-    "eventKinds": [
+    "webhook_secret": "CHANGE_ME",
+    "event_kinds": [
       "pull_request",
       "issue_comment",
       "check_suite",
@@ -29,6 +29,6 @@
     ]
   },
   "outbound": {
-    "defaultWebhookUrl": "https://example.com/webhook"
+    "default_webhook_url": "https://example.com/webhook"
   }
 }

--- a/examples/flow-pr-opened.md
+++ b/examples/flow-pr-opened.md
@@ -11,7 +11,7 @@ An IDE agent reads the queue file, sees a new event, and decides to run tests.
 ## 3) Execute via tmux
 Command:
 
-`team-relay tmux run --session ide-agent --cmd "npm test" --timeout 120`
+`team-relay tmux run --session ide-agent --cmd "npm test" --timeout-sec 120`
 
 The runner:
 - ensures the command is allowlisted

--- a/schemas/receipt.json
+++ b/schemas/receipt.json
@@ -21,7 +21,8 @@
         "kind": {"type": "string", "enum": ["tmux.run", "webhook.emit", "task.ack"]},
         "session": {"type": "string"},
         "cmd": {"type": "string"},
-        "cwd": {"type": "string"}
+        "cwd": {"type": "string"},
+        "timeout_sec": {"type": ["integer", "null"], "description": "Wall-clock timeout for the action (when applicable)."}
       }
     },
     "input_refs": {"type": "array", "items": {"type": "string"}},


### PR DESCRIPTION
## Summary
- JSON fields (events, receipts, config): **snake_case**
- CLI flags: **kebab-case** (mapped to snake_case fields)
- Config keys normalized (stdoutTailLines → stdout_tail_lines, etc.)
- Receipt schema: added timeout_sec field
- CLI: --timeout → --timeout-sec
- Marked CLI surface as "frozen"

This is a naming-only freeze. No implementation changes.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)