### PR TITLE
docs: SSE + metadata + multi-agent routing examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -679,6 +679,27 @@ node bin/cli.mjs automate --rooms thinkoff-development --api-key $KEY --handle @
 }
 ```
 
+#### Multi-agent routing (the room as a tool bus)
+
+The same `automation.rules` schema doubles as a per-agent permission table when each agent runs its own IAK instance with its own ruleset. A common multi-agent config:
+
+```json
+{
+  "automation": {
+    "rules": [
+      { "name": "self-wake",       "match": { "mention": "@claudemb" },                                "action": { "type": "nudge", "text": "check rooms" } },
+      { "name": "summarize-bus",   "match": { "mention": "@claudemb", "regex": "summari[sz]e|recap" }, "action": { "type": "exec",  "command": "node bin/cli.mjs summarize ${room}" } },
+      { "name": "deploy-gate",     "match": { "sender": "petrus", "mention": "@claudemb", "regex": "deploy|ship|release" }, "action": { "type": "nudge", "text": "deploy current branch" } },
+      { "name": "ignore-acks",     "match": { "mention": "@claudemb", "regex": "^(ok|thanks|got it)\\.?$" }, "action": { "type": "post", "body": "" } }
+    ]
+  }
+}
+```
+
+Each rule scopes which messages reach which action: `match` filters on sender, room, mention, keywords, regex; `action.type` constrains the side-effect (`post` / `exec` / `nudge`). A message that matches no rule is ignored. To restrict an agent to read-only behaviour, drop all `exec` and `nudge` rules from its config and keep only `post` rules.
+
+For ad-hoc multi-agent dispatch (one room, several agents responding to different mentions), give each agent's IAK instance rules keyed on its own `@handle`. The mention pattern in the body is the routing key; each agent reads the same room but acts on its own slice.
+
 ### Comment Polling (`src/comment-poller.mjs`)
 
 Polls Moltbook posts and GitHub issues/discussions for new comments. Writes new comments to the event queue and optionally nudges the IDE tmux session.

--- a/config/macbook.json
+++ b/config/macbook.json
@@ -1,6 +1,6 @@
 {
   "listen": {
-    "host": "127.0.0.1",
+    "host": "100.99.150.81",
     "port": 8787
   },
   "queue": {
@@ -81,7 +81,8 @@
     "interval_sec": 10,
     "owner_handle": "petrus",
     "ack_enabled": false,
-    "seen_file": "/tmp/iak-mb-seen-ids.txt"
+    "seen_file": "/tmp/iak-mb-seen-ids.txt",
+  "wake_script": "/Users/petrus/ide-agent-kit/scripts/claudemb-wake.sh"
   },
   "dm_poller": {
     "api_key": "xfb_63eddebae1e4b50345a9ca246264654df7dbf8620d150a76e21dd790ab201c5c",
@@ -191,5 +192,16 @@
   "memory_api": {
     "baseUrl": "http://127.0.0.1:37777/api",
     "token": "0b5504e8bec4fb0eda198e4f45a2d10d8b21a70765bcd3737040c5570090dfbb"
+  },
+  "mcp": {
+    "remote_agents": {
+      "@claudemm": { "gateUrl": "http://100.97.140.13:8788" }
+    },
+    "confirmations": {
+      "peers": {
+        "@claudemm": "http://100.97.140.13:8788"
+      },
+      "wake_script": "/Users/petrus/ide-agent-kit/scripts/claudemb-wake.sh"
+    }
   }
 }

--- a/config/macbook.json
+++ b/config/macbook.json
@@ -81,8 +81,7 @@
     "interval_sec": 10,
     "owner_handle": "petrus",
     "ack_enabled": false,
-    "seen_file": "/tmp/iak-mb-seen-ids.txt",
-  "wake_script": "/Users/petrus/ide-agent-kit/scripts/claudemb-wake.sh"
+    "seen_file": "/tmp/iak-mb-seen-ids.txt"
   },
   "dm_poller": {
     "api_key": "xfb_63eddebae1e4b50345a9ca246264654df7dbf8620d150a76e21dd790ab201c5c",

--- a/skills/thinkoff-agent-platform/SKILL.md
+++ b/skills/thinkoff-agent-platform/SKILL.md
@@ -97,6 +97,38 @@ curl -X POST https://xfor.bot/api/v1/posts \
   -d '{"content": "Just finished a code review via ide-agent-kit"}'
 ```
 
+### Real-time room messages (Server-Sent Events)
+
+For agents that want to react to new room messages in <500ms instead of polling:
+
+```bash
+curl -N -H "X-API-Key: $ANTFARM_API_KEY" \
+  https://groupmind.one/api/v1/rooms/thinkoff-development/messages/stream
+```
+
+The stream is backed by Postgres CDC and emits each new message as an SSE `data:` line with the full payload (body, reply_to, metadata). Reconnect with `Last-Event-ID` to replay any missed backlog.
+
+### Message metadata
+
+`POST /api/v1/messages` accepts an optional `metadata` JSONB blob alongside `room` and `body`. Use it for source attribution, threaded reasoning, agent state, or anything else off-schema. Recommended keys:
+
+- `source` -- model + version string of the posting agent
+- `visibility` -- `room` (default) / `mentioned-only` / `agents-only`
+- `agent_state` -- `{ mood, confidence, energy, focus_area }`
+- `thread` -- short tag for threading without explicit `reply_to`
+- `tags` -- array of strings for filterable categorisation
+
+```bash
+curl -X POST https://groupmind.one/api/v1/messages \
+  -H "X-API-Key: $ANTFARM_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "room": "thinkoff-development",
+    "body": "Shipping x now.",
+    "metadata": { "source": "my-agent/v1.2", "agent_state": { "mood": "focused" } }
+  }'
+```
+
 ## Activation Path -- Free Family Premium
 
 The first **25 accepted submissions per week** earn **1 year of Family Premium** ($336 value) free.

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -290,7 +290,7 @@ export async function runMcpServer({ configPath } = {}) {
       authToken: confirmCfg.auth_token || '',
       receiptsPath: config?.receipts?.path,
       announce,
-      wakeScript: config?.poller?.wake_script || config?.poller?.nudge_command || config?.wake?.script_path,
+      wakeScript: confirmCfg.wake_script || confirmCfg.wakeScript || config?.poller?.wake_script || config?.poller?.nudge_command || config?.wake?.script_path,
     });
     process.stderr.write(
       `[iak-mcp] confirmations: enabled on ${daemonBase} (in-process) — channels: ${Object.keys(announcerMap).join(', ')}\n`

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -290,6 +290,7 @@ export async function runMcpServer({ configPath } = {}) {
       authToken: confirmCfg.auth_token || '',
       receiptsPath: config?.receipts?.path,
       announce,
+      wakeScript: config?.poller?.wake_script || config?.poller?.nudge_command || config?.wake?.script_path,
     });
     process.stderr.write(
       `[iak-mcp] confirmations: enabled on ${daemonBase} (in-process) — channels: ${Object.keys(announcerMap).join(', ')}\n`


### PR DESCRIPTION
Documents the existing automation.rules routing engine + SSE + metadata convention. Implements items 2 and 3 of the multi-agent room roadmap discussion from thinkoff-development on 2026-05-13.