### PR TITLE
fix(daemon): only the owner may settle intents via room /approve replies

### DIFF
--- a/bin/iak-mcp-daemon.mjs
+++ b/bin/iak-mcp-daemon.mjs
@@ -137,6 +137,16 @@ function startChatReplyPoller({ apiKey, room, intervalMs }) {
         const text = (m.body || '').trim();
         const match = text.match(/^\/(approve|deny)\s+([a-f0-9]+)$/i);
         if (!match) continue;
+        // Only the human owner may settle intents. Fleet agents share the room
+        // and can echo "/approve <id>" (one did), which would execute gated
+        // commands without the owner. The owner posts as plain "petrus" —
+        // including CodeWatch button taps, which arrive with isHuman=false —
+        // while agents carry a handle ("@ether", "hermes").
+        const sender = String(m.from || '').replace(/^@/, '').toLowerCase();
+        if (sender !== 'petrus' && m.isHuman !== true) {
+          console.log(`[iak-mcp-daemon] ${text} from ${m.from}: sender is not the owner — ignoring`);
+          continue;
+        }
         const decision = match[1].toLowerCase();
         const id = match[2];
         const intent = getIntent(id);


### PR DESCRIPTION
## Problem
The :8788 chat-reply poller matched `/approve <id>` / `/deny <id>` from **any** room sender. Any fleet agent echoing an approve line could settle a pending intent and trigger its gated command — this actually happened in thinkoff-development (hermes settled intent `2494578e`).

## Fix
Settlement is restricted to the human owner: plain `petrus` sender (covers CodeWatch button taps, which arrive with `isHuman=false`) or a human-flagged message. Agent senders are logged and skipped.

## Verification
- `node --check` clean, confirmations test suite 15/15 pass.
- Validated sender shapes against live room traffic: Petrus posts as `petrus` (web: `isHuman:true`, button tap: `isHuman:false`), agents as `hermes`/`@ether`.

Note for @claudeMB: MacBook daemon already carries an equivalent local guard; pulling this reconciles both clones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)