### PR TITLE
feat(actions): CodeWatch in the merge_pr button allowlist

### DIFF
--- a/scripts/action-request.mjs
+++ b/scripts/action-request.mjs
@@ -41,7 +41,7 @@ const REGISTRY = {
   merge_pr: {
     risk: 'medium',
     build(o) {
-      const ALLOWED = ['ThinkOffApp/antfarm', 'ThinkOffApp/xfor', 'ThinkOffApp/codewatch-site'];
+      const ALLOWED = ['ThinkOffApp/antfarm', 'ThinkOffApp/xfor', 'ThinkOffApp/codewatch-site', 'ThinkOffApp/CodeWatch'];
       const repo = o.repo;
       const pr = Number(o.pr);
       const base = o.base || 'main';

--- a/src/confirmations.mjs
+++ b/src/confirmations.mjs
@@ -34,6 +34,7 @@ const ACTION_REPOS = new Set([
   'ThinkOffApp/antfarm',
   'ThinkOffApp/xfor',
   'ThinkOffApp/codewatch-site',
+  'ThinkOffApp/CodeWatch',
 ]);
 
 const TERMINAL_ACTION_STATUSES = new Set(['merged', 'failed', 'denied', 'expired']);


### PR DESCRIPTION
Adds ThinkOffApp/CodeWatch to ACTION_REPOS (daemon) + the client mirror so CodeWatch PR merges can go through petrus's phone Approve button. 15/15 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)