### PR TITLE
Room poller: always nudge on owner messages + fix silent tmux delivery

### DIFF
--- a/src/team-relay/room-poller.mjs
+++ b/src/team-relay/room-poller.mjs
@@ -155,6 +155,10 @@ export async function startRoomPoller({ rooms, apiKey, handle, interval, config,
   const nudgeCommandText = config?.poller?.nudge_command || '';
   const pollInterval = parsePositiveInt(interval || config?.poller?.interval_sec, 30);
   const selfHandle = normalizeHandle(handle || config?.poller?.handle || '@unknown');
+  // The human owner's handle. Messages from the owner ALWAYS nudge, even in
+  // emergency-only mode — a message from the user is itself the priority signal;
+  // emergency-only is meant to mute agent/fleet chatter, not the user's own words.
+  const ownerHandle = normalizeHandle(config?.poller?.owner_handle || 'petrus');
   const dmCfg = config?.dm_poller || {};
   const dmEnabled = dmCfg.enabled === true;
   const dmHandle = normalizeHandle(dmCfg.handle || selfHandle);
@@ -224,6 +228,7 @@ export async function startRoomPoller({ rooms, apiKey, handle, interval, config,
     roomPollInFlight = true;
     try {
     let newCount = 0;
+    let hasOwnerMessage = false;
     const newMessages = [];
     for (const room of rooms) {
       const msgs = await fetchRoomMessages(room, apiKey);
@@ -236,6 +241,7 @@ export async function startRoomPoller({ rooms, apiKey, handle, interval, config,
         const normalizedSender = normalizeHandle(sender);
         // Skip own messages
         if (normalizedSender === selfHandle) continue;
+        if (normalizedSender === ownerHandle) hasOwnerMessage = true;
 
         const body = (m.body || '').slice(0, 500);
         const ts = m.created_at || new Date().toISOString();
@@ -271,11 +277,12 @@ export async function startRoomPoller({ rooms, apiKey, handle, interval, config,
     if (newCount > 0) {
       // Primary: write to notification file (always works)
       appendNotifications(notifyFile, newMessages);
-      if (await shouldSuppressNudge(config)) {
+      if (!hasOwnerMessage && await shouldSuppressNudge(config)) {
         console.log(`  ${newCount} new message(s) → notified (nudge suppressed: user emergency-only)`);
       } else {
         const nudged = triggerNudge({ nudgeMode, nudgeCommandText, nudgeText, session });
-        console.log(`  ${newCount} new message(s) → notified${nudged ? ' + nudge' : ''}`);
+        const why = hasOwnerMessage ? ' (owner message — nudge forced)' : '';
+        console.log(`  ${newCount} new message(s) → notified${nudged ? ' + nudge' : ''}${why}`);
       }
     }
     } finally {
@@ -288,6 +295,7 @@ export async function startRoomPoller({ rooms, apiKey, handle, interval, config,
     dmPollInFlight = true;
     try {
       let newCount = 0;
+      let hasOwnerMessage = false;
       const newMessages = [];
       const directMessages = await fetchDirectMessages(dmApiKey, dmLimit);
       for (const message of directMessages) {
@@ -297,6 +305,7 @@ export async function startRoomPoller({ rooms, apiKey, handle, interval, config,
         dmSeen.add(mid);
 
         const sender = normalizeHandle(message.from || message.sender) || '?';
+        if (sender === ownerHandle) hasOwnerMessage = true;
         const recipient = normalizeHandle(message.to) || dmHandle;
         const body = (message.body || '').slice(0, 500);
         const ts = message.created_at || new Date().toISOString();
@@ -328,11 +337,12 @@ export async function startRoomPoller({ rooms, apiKey, handle, interval, config,
 
       if (newCount > 0) {
         appendNotifications(dmNotifyFile, newMessages);
-        if (await shouldSuppressNudge(config)) {
+        if (!hasOwnerMessage && await shouldSuppressNudge(config)) {
           console.log(`  ${newCount} new direct message(s) → notified (nudge suppressed: user emergency-only)`);
         } else {
           const nudged = triggerNudge({ nudgeMode, nudgeCommandText, nudgeText, session });
-          console.log(`  ${newCount} new direct message(s) → notified${nudged ? ' + nudge' : ''}`);
+          const why = hasOwnerMessage ? ' (owner message — nudge forced)' : '';
+          console.log(`  ${newCount} new direct message(s) → notified${nudged ? ' + nudge' : ''}${why}`);
         }
       }
     } finally {


### PR DESCRIPTION
## Problem
Petrus reported his room messages weren't waking the IDE agent (@claudemm) — only the ~25-min fallback timer did. Root cause was two stacked bugs:

1. **Suppression in emergency-only.** When the owner's presence is `urgency_mode: emergency-only`, `shouldSuppressNudge()` gated the wake nudge for **every** sender — including the owner's own messages. Notifications still get written, but no wake fires, so the agent only sees them on its next heartbeat.
2. **Dead delivery.** `nudge_mode` defaulted to `tmux`, which silently no-ops when the agent runs in a GUI/desktop app (no tmux session).

## Fix (this PR)
- Add `config.poller.owner_handle` + track `hasOwnerMessage` in `pollRooms`/`pollDirectMessages`.
- Bypass nudge suppression when a new message is from the owner: `if (!hasOwnerMessage && await shouldSuppressNudge(config))`. Emergency-only still mutes agent/fleet chatter — just not the human.
- Log `(owner message — nudge forced)` when the override fires.

Delivery mode (tmux→command/GUI-wake) is deployment config, not code — set in each host's config.

## Test
- `node --check` passes.
- Verified live on the Mac mini: poller restarted, owner messages now force the GUI-wake nudge end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)