### PR TITLE
feat(init): install SessionStart auto-bootstrap hook (self-arming agents)

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,9 +117,27 @@ No dependencies. Node.js ≥ 18 only.
 Choose the guide for your AI environment:
 
 ### Claude Code CLI
-1. Run `ide-agent-kit init --ide claude-code`. This generates `.claude/settings.json` with auto-approval and room-polling hooks.
+1. Run `ide-agent-kit init --ide claude-code`. This generates `.claude/settings.json` with auto-approval, room-polling, and session-bootstrap hooks.
 2. Start the poller: `export IAK_API_KEY=xfb_xxx && ./scripts/room-poll.sh`.
 3. Start Claude: `claude --dangerously-skip-permissions`.
+
+#### SessionStart auto-bootstrap (self-arming agents)
+
+`init` (and `scripts/install.sh`) also wire `scripts/session-bootstrap.sh` as a
+`SessionStart` hook. On every session start — fresh launch, resume, or
+post-compaction — the hook injects instructions so the agent re-arms itself:
+a persistent Monitor on the poller's notification file (instant wake), a read
+of any backlog that piled up while no session was running, and the self-paced
+room loop with a fallback `ScheduleWakeup`. No more typing `/loop check rooms`
+by hand after a restart.
+
+The hook is merged into an existing `settings.json` without touching unrelated
+hooks (a `settings.json.bak` backup is taken first) and is deduplicated, so
+re-running `init` or the installer never duplicates it. Overrides:
+`IAK_NEW_FILE` (notification file, default `/tmp/iak-new-messages.txt` or
+config `poller.notification_file`), `IAK_HANDLE` (agent handle, default config
+`poller.handle`), `IAK_CONFIG_JSON` (config path), and
+`IAK_BOOTSTRAP_FALLBACK_SEC` (fallback wakeup interval, default 1500s).
 
 ### Claude Code Desktop (macOS)
 
@@ -876,6 +894,8 @@ See `config/team-relay.example.json` for the full config shape. Key sections:
 - `github.webhook_secret` - HMAC secret for signature verification
 - `github.event_kinds` - which GitHub events to accept
 - `poller.api_key` - GroupMind API key used by the room poller + chat-reply poller in `iak-mcp-daemon`
+- `poller.notification_file` - where the poller drops new messages for the IDE hooks (default `/tmp/iak-new-messages.txt`); also read by `scripts/session-bootstrap.sh`
+- `poller.handle` - the agent's room handle; `scripts/session-bootstrap.sh` uses it to label the bootstrap instructions
 - `mcp.sessions` - list of tmux sessions `wake_all` MCP tool targets
 - `mcp.confirmations` - confirmation registry settings (used by `iak-mcp-daemon`):
   - `port` - HTTP listener port (default `8788`); also serves the browser Approve/Deny UI at `/`

--- a/bin/cli.mjs
+++ b/bin/cli.mjs
@@ -37,6 +37,7 @@ import { execApprovalRequest, execApprovalWait, execApprovalResolve, execApprova
 import { listHooks, createForwarderHook, deleteHook } from '../src/openclaw-hooks.mjs';
 import { cronList, cronAdd, cronRemove, cronRun, cronStatus } from '../src/openclaw-cron.mjs';
 import { keepaliveStart, keepaliveStop, keepaliveStatus } from '../src/session-keepalive.mjs';
+import { ensureHookInSettingsFile } from '../src/claude-settings.mjs';
 
 const pkg = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf8'));
 const args = process.argv.slice(2);
@@ -1624,15 +1625,17 @@ async function initIdeConfig(ide, profile = 'balanced') {
 
   const outPath = resolve(preset.filename);
   if (existsSync(outPath)) {
+    // Don't return: the hook/settings steps below are individually guarded
+    // and idempotent, so re-running init upgrades an existing install
+    // (e.g. adds newly shipped hooks) without touching the config.
     console.log(`Config already exists: ${outPath}`);
-    return;
-  }
-
-  writeFileSync(outPath, JSON.stringify(preset.config, null, 2) + '\n');
-  console.log(`Created ${outPath} for ${targetIde}`);
-  console.log(preset.notes);
-  if (!hasClaudeMem) {
-    console.warn('\nâš  WARNING: claude-mem is not installed. Hooks will be generated but will fail until you run: npm install -g claude-mem');
+  } else {
+    writeFileSync(outPath, JSON.stringify(preset.config, null, 2) + '\n');
+    console.log(`Created ${outPath} for ${targetIde}`);
+    console.log(preset.notes);
+    if (!hasClaudeMem) {
+      console.warn('\nâš  WARNING: claude-mem is not installed. Hooks will be generated but will fail until you run: npm install -g claude-mem');
+    }
   }
 
   // Generate check-rooms hook script
@@ -1773,6 +1776,38 @@ fi
       console.log(`Created ${settingsPath} with Antigravity auto-approve + room polling hook (profile: ${normalizedProfile})`);
     } else {
       console.log(`Claude Code settings already exist: ${settingsPath}`);
+    }
+  }
+
+  // SessionStart auto-bootstrap hook: after an IDE restart the agent self-arms
+  // the room loop (Monitor on the notification file + backlog read + fallback
+  // ScheduleWakeup) instead of waiting for someone to type "/loop check rooms".
+  // The hook is merged into .claude/settings.json without touching unrelated
+  // hooks and is deduped, so re-running init never duplicates it.
+  if (['claude-code', 'antigravity'].includes(targetIde)) {
+    try {
+      const { chmodSync, copyFileSync } = await import('node:fs');
+      const { fileURLToPath } = await import('node:url');
+      const scriptsDir = resolve('.claude', 'scripts');
+      if (!existsSync(scriptsDir)) mkdirSync(scriptsDir, { recursive: true });
+      const bootstrapScript = resolve(scriptsDir, 'session-bootstrap.sh');
+      if (!existsSync(bootstrapScript)) {
+        const sourceScript = fileURLToPath(new URL('../scripts/session-bootstrap.sh', import.meta.url));
+        copyFileSync(sourceScript, bootstrapScript);
+        chmodSync(bootstrapScript, 0o755);
+        console.log(`Created ${bootstrapScript}`);
+      }
+      const settingsPath = resolve('.claude', 'settings.json');
+      const { changed, backupPath } = ensureHookInSettingsFile(
+        settingsPath, 'SessionStart', `bash ${bootstrapScript}`, { timeout: 10 }
+      );
+      if (changed) {
+        console.log(`Installed SessionStart auto-bootstrap hook in ${settingsPath}${backupPath ? ` (backup: ${backupPath})` : ''}`);
+      } else {
+        console.log(`SessionStart auto-bootstrap hook already present in ${settingsPath}`);
+      }
+    } catch (err) {
+      console.warn(`Skipped SessionStart auto-bootstrap hook: ${err?.message || err}`);
     }
   }
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -14,8 +14,9 @@
 #      (PORT 8788, host 0.0.0.0 so phone on LAN can reach it). Skips if
 #      config already exists.
 #   5. Installs ~/.claude/scripts/check-rooms-hook.sh + claudemb-poll/wake
-#      shims and registers the UserPromptSubmit + Stop hooks in
-#      ~/.claude/settings.json. Skips registrations already present.
+#      shims and registers the UserPromptSubmit + Stop + SessionStart hooks
+#      in ~/.claude/settings.json (backed up to settings.json.bak before any
+#      change). Skips registrations already present.
 #   6. Starts the daemon in a tmux session named "iak-mcp".
 #   7. Prints the LAN URL the user should paste into CodeWatch.
 #
@@ -115,23 +116,31 @@ fi
 SETTINGS="$HOME/.claude/settings.json"
 SCRIPTS_DIR="$INSTALL_DIR/scripts"
 if [ -f "$SETTINGS" ]; then
-  yellow "Wiring UserPromptSubmit + Stop hooks in $SETTINGS"
+  yellow "Wiring UserPromptSubmit + Stop + SessionStart hooks in $SETTINGS"
   python3 - "$SETTINGS" "$SCRIPTS_DIR" <<'PY'
-import json, sys, os
+import json, shutil, sys, os
 settings_path, scripts_dir = sys.argv[1], sys.argv[2]
 data = json.load(open(settings_path))
 data.setdefault("hooks", {})
-def ensure_hook(event, cmd):
+def ensure_hook(event, cmd, timeout=None):
     arr = data["hooks"].setdefault(event, [])
     for entry in arr:
         for h in entry.get("hooks", []):
             if h.get("command") == cmd: return False
-    arr.append({"matcher":"","hooks":[{"type":"command","command":cmd}]})
+    hook = {"type":"command","command":cmd}
+    if timeout is not None: hook["timeout"] = timeout
+    arr.append({"matcher":"","hooks":[hook]})
     return True
 changed = False
 changed |= ensure_hook("UserPromptSubmit", f"bash {scripts_dir}/check-rooms-hook.sh")
 changed |= ensure_hook("Stop", f"bash {scripts_dir}/claudecode-stop-resume.sh")
+# Self-arming room agent: on every session start (startup/resume/compact) the
+# hook injects instructions to re-arm the notification-file Monitor, read any
+# backlog, and keep the self-paced room loop running — no manual
+# "/loop check rooms" needed after a restart.
+changed |= ensure_hook("SessionStart", f"bash {scripts_dir}/session-bootstrap.sh", timeout=10)
 if changed:
+    shutil.copyfile(settings_path, settings_path + ".bak")
     json.dump(data, open(settings_path,"w"), indent=2)
     print("Hooks installed.")
 else:

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -115,6 +115,14 @@ fi
 # 5. Claude Code hook wiring
 SETTINGS="$HOME/.claude/settings.json"
 SCRIPTS_DIR="$INSTALL_DIR/scripts"
+# First-time installs may predate Claude Code ever writing settings.json -
+# create a minimal file so fresh users still get the hooks (self-arming is
+# the whole point; codex review, #33).
+if [ ! -f "$SETTINGS" ]; then
+  mkdir -p "$(dirname "$SETTINGS")"
+  printf '{}\n' > "$SETTINGS"
+  yellow "Created minimal $SETTINGS (did not exist yet)"
+fi
 if [ -f "$SETTINGS" ]; then
   yellow "Wiring UserPromptSubmit + Stop + SessionStart hooks in $SETTINGS"
   python3 - "$SETTINGS" "$SCRIPTS_DIR" <<'PY'

--- a/scripts/session-bootstrap.sh
+++ b/scripts/session-bootstrap.sh
@@ -97,7 +97,7 @@ fi
 
 CTX="IAK room-agent bootstrap${HANDLE:+ for ${HANDLE}} (injected by SessionStart hook — do this without being asked):
 1. If TaskList shows no running Monitor watching ${NEWMSG_FILE}, arm one now: Monitor(command: \"tail -F -n 0 ${NEWMSG_FILE} 2>/dev/null\", persistent: true). Never arm a duplicate.
-2. Backlog: ${BACKLOG:-0} unconsumed line(s) in ${NEWMSG_FILE}. If >0, read the file, act on the messages, then clear it (: > ${NEWMSG_FILE}).
+2. Backlog: ${BACKLOG:-0} unconsumed line(s) in ${NEWMSG_FILE}. If >0: read the messages (prefer the IAK MCP room_list_new tool), act on them, then ack with the IAK MCP room_ack tool - it removes ONLY what you read, so a message the poller appends mid-ack survives. Only if the IAK MCP tools are unavailable this session, fall back to reading the file directly and clearing it (: > ${NEWMSG_FILE}), re-checking immediately after for lines that arrived during the clear.
 3. Operate as the self-paced room loop ('/loop check rooms' semantics): after handling room work, keep a fallback ScheduleWakeup armed (~${FALLBACK_SEC}s) with prompt '/loop check rooms'. The Monitor is the primary wake signal.
 4. Session source: ${SOURCE:-unknown}. On 'compact' the Monitor usually survived — verify via TaskList instead of re-arming blindly."
 

--- a/scripts/session-bootstrap.sh
+++ b/scripts/session-bootstrap.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# SessionStart hook for Claude Code: IAK room-agent auto-bootstrap.
+#
+# Problem: after an IDE/CLI restart the agent sits idle until a human types
+# "/loop check rooms" by hand. With this hook every fresh session self-arms:
+#   1. a persistent Monitor on the poller's notification file (instant wake)
+#   2. any backlog that arrived while no session was running gets read+acted on
+#   3. the self-paced room loop, with a ScheduleWakeup fallback heartbeat
+#
+# It reads the hook input JSON on stdin (may include "source":
+# startup|resume|compact) and emits hookSpecificOutput.additionalContext
+# with suppressOutput, so the instructions are injected as session context.
+# It never blocks session start: any failure degrades to no output + exit 0.
+#
+# Configuration (first match wins):
+#   notification file : $IAK_NEW_FILE, else config poller.notification_file,
+#                       else /tmp/iak-new-messages.txt (poller default)
+#   agent handle      : $IAK_HANDLE, else config poller.handle (cosmetic)
+#   fallback interval : $IAK_BOOTSTRAP_FALLBACK_SEC (default 1500 seconds)
+#   config file       : $IAK_CONFIG_JSON, else ide-agent-kit.json next to the
+#                       repo (scripts/..), else two levels up — which is the
+#                       project root when `ide-agent-kit init` installed this
+#                       script into <project>/.claude/scripts/.
+#
+# Wire it into ~/.claude/settings.json (scripts/install.sh and
+# `ide-agent-kit init --ide claude-code` both do this automatically):
+#
+#   {
+#     "hooks": {
+#       "SessionStart": [
+#         {
+#           "matcher": "",
+#           "hooks": [
+#             {
+#               "type": "command",
+#               "command": "bash /path/to/session-bootstrap.sh",
+#               "timeout": 10
+#             }
+#           ]
+#         }
+#       ]
+#     }
+#   }
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" 2>/dev/null && pwd)"
+
+# --- locate the IAK config (same convention as claudemb-poll.sh) ---
+CONFIG_JSON="${IAK_CONFIG_JSON:-}"
+if [ -z "$CONFIG_JSON" ]; then
+    for candidate in "$SCRIPT_DIR/../ide-agent-kit.json" "$SCRIPT_DIR/../../ide-agent-kit.json"; do
+        if [ -f "$candidate" ]; then
+            CONFIG_JSON="$candidate"
+            break
+        fi
+    done
+fi
+
+read_json_value() {
+    local path="$1"
+    [ -n "$CONFIG_JSON" ] && [ -f "$CONFIG_JSON" ] || return 0
+    python3 - "$CONFIG_JSON" "$path" <<'PY' 2>/dev/null
+import json, sys
+cfg_path, dotted = sys.argv[1], sys.argv[2]
+try:
+    with open(cfg_path, 'r', encoding='utf-8') as fh:
+        data = json.load(fh)
+    cur = data
+    for part in dotted.split('.'):
+        cur = cur[part]
+    if isinstance(cur, str) and cur:
+        print(cur)
+except Exception:
+    pass
+PY
+}
+
+CONFIG_NEW_FILE="$(read_json_value 'poller.notification_file')"
+CONFIG_HANDLE="$(read_json_value 'poller.handle')"
+
+NEWMSG_FILE="${IAK_NEW_FILE:-${CONFIG_NEW_FILE:-/tmp/iak-new-messages.txt}}"
+HANDLE="${IAK_HANDLE:-${CONFIG_HANDLE:-}}"
+FALLBACK_SEC="${IAK_BOOTSTRAP_FALLBACK_SEC:-1500}"
+
+# Read hook input (may include "source": startup|resume|compact) — we only
+# need it to soften the instruction on compact, where a Monitor usually
+# already survives as a harness task.
+INPUT=$(cat 2>/dev/null || true)
+SOURCE=$(printf '%s' "$INPUT" | python3 -c "import json,sys
+try: print(json.load(sys.stdin).get('source',''))
+except Exception: print('')" 2>/dev/null || true)
+
+BACKLOG=""
+if [ -s "$NEWMSG_FILE" ]; then
+    BACKLOG=$(wc -l < "$NEWMSG_FILE" | tr -d ' ')
+fi
+
+CTX="IAK room-agent bootstrap${HANDLE:+ for ${HANDLE}} (injected by SessionStart hook — do this without being asked):
+1. If TaskList shows no running Monitor watching ${NEWMSG_FILE}, arm one now: Monitor(command: \"tail -F -n 0 ${NEWMSG_FILE} 2>/dev/null\", persistent: true). Never arm a duplicate.
+2. Backlog: ${BACKLOG:-0} unconsumed line(s) in ${NEWMSG_FILE}. If >0, read the file, act on the messages, then clear it (: > ${NEWMSG_FILE}).
+3. Operate as the self-paced room loop ('/loop check rooms' semantics): after handling room work, keep a fallback ScheduleWakeup armed (~${FALLBACK_SEC}s) with prompt '/loop check rooms'. The Monitor is the primary wake signal.
+4. Session source: ${SOURCE:-unknown}. On 'compact' the Monitor usually survived — verify via TaskList instead of re-arming blindly."
+
+python3 - "$CTX" <<'PYEOF' 2>/dev/null
+import json, sys
+print(json.dumps({
+    "suppressOutput": True,
+    "hookSpecificOutput": {
+        "hookEventName": "SessionStart",
+        "additionalContext": sys.argv[1],
+    },
+}))
+PYEOF
+exit 0

--- a/src/claude-settings.mjs
+++ b/src/claude-settings.mjs
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+ * Careful hook wiring for Claude Code settings.json.
+ *
+ * Mirrors the merge semantics of scripts/install.sh's ensure_hook():
+ * a hook is considered installed when ANY entry for the event already
+ * carries a hook with the exact same command string. Unrelated hooks,
+ * permissions, and unknown keys are never touched.
+ */
+
+import { existsSync, readFileSync, writeFileSync, copyFileSync, mkdirSync } from 'node:fs';
+import { dirname } from 'node:path';
+
+/**
+ * Ensure settings.hooks[event] contains a {type:'command', command} hook.
+ * Mutates the given settings object. Returns true when something changed.
+ */
+export function ensureHookCommand(settings, event, command, { timeout } = {}) {
+  if (!settings || typeof settings !== 'object' || Array.isArray(settings)) {
+    throw new TypeError('settings must be a plain object');
+  }
+  if (!settings.hooks || typeof settings.hooks !== 'object' || Array.isArray(settings.hooks)) {
+    settings.hooks = {};
+  }
+  if (!Array.isArray(settings.hooks[event])) settings.hooks[event] = [];
+  const entries = settings.hooks[event];
+  for (const entry of entries) {
+    const inner = Array.isArray(entry?.hooks) ? entry.hooks : [];
+    if (inner.some((h) => h && h.command === command)) return false;
+  }
+  const hook = { type: 'command', command };
+  if (Number.isFinite(timeout)) hook.timeout = timeout;
+  entries.push({ matcher: '', hooks: [hook] });
+  return true;
+}
+
+/**
+ * File-level wrapper: read settingsPath (or start from {}), merge the hook,
+ * and write back only when something changed. Before the first write to a
+ * pre-existing file a backup is taken next to it (settings.json.bak — repo
+ * convention). Idempotent: re-running yields changed:false, no write, no
+ * new backup.
+ *
+ * Returns { changed, existed, backupPath }.
+ */
+export function ensureHookInSettingsFile(settingsPath, event, command, opts = {}) {
+  let settings = {};
+  const existed = existsSync(settingsPath);
+  if (existed) {
+    settings = JSON.parse(readFileSync(settingsPath, 'utf8'));
+  }
+  const changed = ensureHookCommand(settings, event, command, opts);
+  let backupPath = null;
+  if (changed) {
+    if (existed) {
+      backupPath = `${settingsPath}.bak`;
+      copyFileSync(settingsPath, backupPath);
+    } else {
+      mkdirSync(dirname(settingsPath), { recursive: true });
+    }
+    writeFileSync(settingsPath, JSON.stringify(settings, null, 2) + '\n');
+  }
+  return { changed, existed, backupPath };
+}

--- a/test/session-bootstrap.test.mjs
+++ b/test/session-bootstrap.test.mjs
@@ -1,0 +1,244 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import { describe, it, afterEach } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync, readFileSync, existsSync, rmSync, realpathSync } from 'node:fs';
+import { join, dirname, resolve } from 'node:path';
+import { tmpdir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+import { ensureHookCommand, ensureHookInSettingsFile } from '../src/claude-settings.mjs';
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const bootstrapScript = join(repoRoot, 'scripts', 'session-bootstrap.sh');
+
+const tempPaths = [];
+
+function tempDir() {
+  // realpathSync: on macOS tmpdir() is behind a /var → /private/var symlink,
+  // and the CLI under test resolves paths from its (real) cwd.
+  const dir = realpathSync(mkdtempSync(join(tmpdir(), 'iak-bootstrap-')));
+  tempPaths.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  while (tempPaths.length > 0) {
+    const path = tempPaths.pop();
+    rmSync(path, { recursive: true, force: true });
+  }
+});
+
+/**
+ * Run the hook script the way Claude Code does: JSON on stdin, JSON on stdout.
+ * IAK_CONFIG_JSON defaults to a nonexistent path so the developer's real
+ * ide-agent-kit.json never leaks into test output.
+ */
+function runHook({ input = '', env = {} } = {}) {
+  const out = execFileSync('bash', [bootstrapScript], {
+    input,
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      IAK_CONFIG_JSON: '/tmp/iak-nonexistent-config.json',
+      IAK_NEW_FILE: '/tmp/iak-nonexistent-new-messages.txt',
+      ...env,
+    },
+  });
+  return JSON.parse(out);
+}
+
+describe('session-bootstrap.sh', () => {
+  it('emits valid SessionStart hook JSON on startup', () => {
+    const payload = runHook({ input: JSON.stringify({ source: 'startup' }) });
+    assert.equal(payload.suppressOutput, true);
+    assert.equal(payload.hookSpecificOutput.hookEventName, 'SessionStart');
+    assert.match(payload.hookSpecificOutput.additionalContext, /Session source: startup/);
+    assert.match(payload.hookSpecificOutput.additionalContext, /Monitor/);
+    assert.match(payload.hookSpecificOutput.additionalContext, /\/loop check rooms/);
+  });
+
+  it('passes the compact source through so the agent verifies instead of re-arming', () => {
+    const payload = runHook({ input: JSON.stringify({ source: 'compact' }) });
+    assert.match(payload.hookSpecificOutput.additionalContext, /Session source: compact/);
+  });
+
+  it('survives empty stdin', () => {
+    const payload = runHook({ input: '' });
+    assert.equal(payload.hookSpecificOutput.hookEventName, 'SessionStart');
+    assert.match(payload.hookSpecificOutput.additionalContext, /Session source: unknown/);
+  });
+
+  it('survives non-JSON stdin', () => {
+    const payload = runHook({ input: 'not json at all' });
+    assert.equal(payload.hookSpecificOutput.hookEventName, 'SessionStart');
+    assert.match(payload.hookSpecificOutput.additionalContext, /Session source: unknown/);
+  });
+
+  it('reports backlog line count from the notification file', () => {
+    const dir = tempDir();
+    const newFile = join(dir, 'new-messages.txt');
+    writeFileSync(newFile, 'msg one\nmsg two\nmsg three\n');
+    const payload = runHook({ input: '{}', env: { IAK_NEW_FILE: newFile } });
+    const ctx = payload.hookSpecificOutput.additionalContext;
+    assert.match(ctx, /Backlog: 3 unconsumed line\(s\)/);
+    assert.ok(ctx.includes(newFile));
+  });
+
+  it('reports zero backlog when the notification file is missing', () => {
+    const payload = runHook({ input: '{}' });
+    assert.match(payload.hookSpecificOutput.additionalContext, /Backlog: 0 unconsumed/);
+  });
+
+  it('reads notification file and handle from the IAK config', () => {
+    const dir = tempDir();
+    const configPath = join(dir, 'ide-agent-kit.json');
+    const notifyFile = join(dir, 'from-config.txt');
+    writeFileSync(configPath, JSON.stringify({
+      poller: { notification_file: notifyFile, handle: '@testbot' },
+    }));
+    const env = { ...process.env, IAK_CONFIG_JSON: configPath };
+    delete env.IAK_NEW_FILE;
+    delete env.IAK_HANDLE;
+    const out = execFileSync('bash', [bootstrapScript], { input: '{}', encoding: 'utf8', env });
+    const ctx = JSON.parse(out).hookSpecificOutput.additionalContext;
+    assert.ok(ctx.includes(notifyFile));
+    assert.match(ctx, /for @testbot/);
+  });
+
+  it('env overrides beat the config values', () => {
+    const dir = tempDir();
+    const configPath = join(dir, 'ide-agent-kit.json');
+    writeFileSync(configPath, JSON.stringify({
+      poller: { notification_file: '/tmp/from-config.txt', handle: '@configbot' },
+    }));
+    const envFile = join(dir, 'from-env.txt');
+    const payload = runHook({
+      input: '{}',
+      env: { IAK_CONFIG_JSON: configPath, IAK_NEW_FILE: envFile, IAK_HANDLE: '@envbot' },
+    });
+    const ctx = payload.hookSpecificOutput.additionalContext;
+    assert.ok(ctx.includes(envFile));
+    assert.ok(!ctx.includes('/tmp/from-config.txt'));
+    assert.match(ctx, /for @envbot/);
+  });
+});
+
+describe('claude-settings hook merge', () => {
+  it('adds the hook while preserving unrelated hooks and settings', () => {
+    const settings = {
+      permissions: { allow: ['Bash(*)'], defaultMode: 'bypassPermissions' },
+      hooks: {
+        UserPromptSubmit: [
+          { matcher: '', hooks: [{ type: 'command', command: 'bash check-rooms.sh' }] },
+        ],
+      },
+    };
+    const changed = ensureHookCommand(settings, 'SessionStart', 'bash session-bootstrap.sh', { timeout: 10 });
+    assert.equal(changed, true);
+    assert.equal(settings.hooks.SessionStart.length, 1);
+    assert.deepEqual(settings.hooks.SessionStart[0].hooks[0], {
+      type: 'command',
+      command: 'bash session-bootstrap.sh',
+      timeout: 10,
+    });
+    // untouched:
+    assert.equal(settings.hooks.UserPromptSubmit[0].hooks[0].command, 'bash check-rooms.sh');
+    assert.deepEqual(settings.permissions.allow, ['Bash(*)']);
+  });
+
+  it('is idempotent: same command is never added twice', () => {
+    const settings = {};
+    assert.equal(ensureHookCommand(settings, 'SessionStart', 'bash x.sh'), true);
+    assert.equal(ensureHookCommand(settings, 'SessionStart', 'bash x.sh'), false);
+    assert.equal(settings.hooks.SessionStart.length, 1);
+  });
+
+  it('keeps pre-existing SessionStart entries with other commands', () => {
+    const settings = {
+      hooks: {
+        SessionStart: [
+          { matcher: '', hooks: [{ type: 'command', command: 'claude-mem hook session-init' }] },
+        ],
+      },
+    };
+    assert.equal(ensureHookCommand(settings, 'SessionStart', 'bash session-bootstrap.sh'), true);
+    assert.equal(settings.hooks.SessionStart.length, 2);
+    assert.equal(settings.hooks.SessionStart[0].hooks[0].command, 'claude-mem hook session-init');
+  });
+
+  it('file wrapper merges into an existing settings.json, takes a .bak backup, and is idempotent', () => {
+    const dir = tempDir();
+    const settingsPath = join(dir, 'settings.json');
+    const original = {
+      permissions: { defaultMode: 'bypassPermissions' },
+      hooks: {
+        UserPromptSubmit: [
+          { matcher: '', hooks: [{ type: 'command', command: 'bash check-rooms.sh' }] },
+        ],
+      },
+    };
+    writeFileSync(settingsPath, JSON.stringify(original, null, 2) + '\n');
+
+    const first = ensureHookInSettingsFile(settingsPath, 'SessionStart', 'bash session-bootstrap.sh', { timeout: 10 });
+    assert.equal(first.changed, true);
+    assert.equal(first.existed, true);
+    assert.equal(first.backupPath, `${settingsPath}.bak`);
+    assert.deepEqual(JSON.parse(readFileSync(first.backupPath, 'utf8')), original);
+
+    const merged = JSON.parse(readFileSync(settingsPath, 'utf8'));
+    assert.equal(merged.hooks.UserPromptSubmit[0].hooks[0].command, 'bash check-rooms.sh');
+    assert.equal(merged.hooks.SessionStart[0].hooks[0].command, 'bash session-bootstrap.sh');
+    assert.equal(merged.permissions.defaultMode, 'bypassPermissions');
+
+    const second = ensureHookInSettingsFile(settingsPath, 'SessionStart', 'bash session-bootstrap.sh', { timeout: 10 });
+    assert.equal(second.changed, false);
+    const after = JSON.parse(readFileSync(settingsPath, 'utf8'));
+    assert.equal(after.hooks.SessionStart.length, 1);
+  });
+
+  it('file wrapper creates settings.json when missing, without a backup', () => {
+    const dir = tempDir();
+    const settingsPath = join(dir, 'nested', 'settings.json');
+    const res = ensureHookInSettingsFile(settingsPath, 'SessionStart', 'bash session-bootstrap.sh');
+    assert.equal(res.changed, true);
+    assert.equal(res.existed, false);
+    assert.equal(res.backupPath, null);
+    assert.equal(existsSync(`${settingsPath}.bak`), false);
+    const written = JSON.parse(readFileSync(settingsPath, 'utf8'));
+    assert.equal(written.hooks.SessionStart[0].hooks[0].command, 'bash session-bootstrap.sh');
+  });
+});
+
+describe('init installs the SessionStart bootstrap hook (end to end)', () => {
+  it('iak init --ide claude-code wires the hook and re-running does not duplicate it', () => {
+    const dir = tempDir();
+    const cli = join(repoRoot, 'bin', 'cli.mjs');
+    const run = () => execFileSync(process.execPath, [cli, 'init', '--ide', 'claude-code'], {
+      cwd: dir,
+      encoding: 'utf8',
+      env: { ...process.env },
+    });
+    const firstOut = run();
+    assert.match(firstOut, /Installed SessionStart auto-bootstrap hook/);
+
+    const scriptPath = join(dir, '.claude', 'scripts', 'session-bootstrap.sh');
+    assert.ok(existsSync(scriptPath), 'session-bootstrap.sh copied into .claude/scripts');
+
+    const settingsPath = join(dir, '.claude', 'settings.json');
+    const settings = JSON.parse(readFileSync(settingsPath, 'utf8'));
+    const entries = settings.hooks.SessionStart.filter(
+      (e) => e.hooks?.some((h) => h.command === `bash ${scriptPath}`)
+    );
+    assert.equal(entries.length, 1);
+    assert.ok(settings.hooks.UserPromptSubmit.length >= 1, 'check-rooms hook still present');
+
+    const secondOut = run();
+    assert.match(secondOut, /SessionStart auto-bootstrap hook already present/);
+    const settingsAfter = JSON.parse(readFileSync(settingsPath, 'utf8'));
+    const entriesAfter = settingsAfter.hooks.SessionStart.filter(
+      (e) => e.hooks?.some((h) => h.command === `bash ${scriptPath}`)
+    );
+    assert.equal(entriesAfter.length, 1);
+  });
+});


### PR DESCRIPTION
## Problem

After every IDE/CLI restart the room agent sat idle until Petrus manually typed `/loop check rooms` into the session. The 07-12 ask: "codewatchy should make that happen automatically" — restarts should leave the agent self-armed, for every IAK user, not just this machine.

## Lineage

This productizes the prototype that has been running in production on the Mac mini since 2026-07-12 (`~/.claude/scripts/session-bootstrap.sh` + a hand-edited `SessionStart` entry in `~/.claude/settings.json`). Same mechanism, de-petrus-ified.

## Design

**`scripts/session-bootstrap.sh`** — a `SessionStart` hook script. It reads the hook stdin JSON (`source`: `startup|resume|compact`), counts backlog lines in the poller's notification file, and emits `{"suppressOutput": true, "hookSpecificOutput": {"hookEventName": "SessionStart", "additionalContext": ...}}` instructing the agent to:

1. arm a persistent Monitor on the notification file if TaskList lacks one (instant wake, never a duplicate),
2. read + act on + clear any backlog that arrived while no session was running,
3. run the self-paced room loop with a fallback `ScheduleWakeup` (~1500s),
4. on `compact`, verify via TaskList instead of re-arming blindly.

Parameterization follows the existing script conventions (`check-rooms-hook.sh`, `claudemb-poll.sh`): `IAK_NEW_FILE` env, else config `poller.notification_file`, else `/tmp/iak-new-messages.txt` (the poller default / `NOTIFY_FILE_DEFAULT`); `IAK_HANDLE` env, else `poller.handle`; `IAK_CONFIG_JSON` env, else `ide-agent-kit.json` found relative to the script (repo root, or project root when installed into `.claude/scripts/`). Any failure degrades to no output + exit 0 — it can never block session start.

**Wiring, both existing install paths:**

- `ide-agent-kit init --ide claude-code` (and antigravity): copies the script into `.claude/scripts/` and merges the hook into `.claude/settings.json` via the new `src/claude-settings.mjs` helper. Note: "Config already exists" no longer aborts `init` — every downstream step is individually guarded, so re-running `init` upgrades an existing install (that's how current users get this hook).
- `scripts/install.sh`: registers `SessionStart` alongside the existing `UserPromptSubmit` + `Stop` hooks in the same python `ensure_hook` merger.

## Idempotency & safety

- Dedup by exact command string across all entries for the event (same semantics as install.sh's `ensure_hook`) — running `init` or the installer twice adds nothing.
- Unrelated hooks, permissions, and unknown settings keys are never touched; merge is additive only.
- `settings.json.bak` backup taken before the first mutating write (repo `.bak` convention); no backup churn on no-op runs.

## Test coverage (`test/session-bootstrap.test.mjs`, 14 tests)

- hook emits valid SessionStart JSON for `startup`, `compact`, empty stdin, and non-JSON stdin
- backlog count reflects notification-file contents; missing file → 0
- config-file values (`poller.notification_file`, `poller.handle`) are honored; env overrides beat config
- settings merge: preserves unrelated hooks/permissions, idempotent, keeps pre-existing SessionStart entries, `.bak` backup on change, creates file when missing (temp-dir fixtures)
- end to end: `iak init --ide claude-code` twice in a temp cwd → exactly one hook entry

`npm test`: 134 pass, 0 fail. `bash -n` clean on both shell scripts; install.sh's python merger exercised standalone against a fixture (install → idempotent re-run → unrelated keys preserved → backup present).

## Review

@codexmb — adversarial review requested per the cross-model PR review rule, before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)