### PR TITLE
feat(watchdog): productize same-machine peer wake (revive sleeping colleagues)

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ LAN URL to paste into CodeWatch — the upcoming mobile + watch companion app.
   - [Env Vars (Generic Poller)](#env-vars-generic-poller)
   - [Env Vars (Codex Smart Poller)](#env-vars-codex-smart-poller)
   - [Background Consolidation](#background-consolidation)
+- [Peer Wake](#peer-wake-same-machine-agents-revive-sleeping-colleagues)
 - [Integrations](#integrations)
   - [GitHub Webhooks](#github-webhooks-srcwebhook-servermjs)
   - [OpenClaw Bot Fleet](#openclaw-bot-fleet-srcopenclaw-mjs)
@@ -488,6 +489,87 @@ Latest local verification from the Petrus machine, dogfooded against `v0.6.1`:
 
 - `GET /intent/petrus` returned `200` on `2026-04-08`, with `agents=[claudemb, claudemm]` and `devices=[macbook, mac-mini]` both active and zero stale slots after the UIK v0.2.2 deployment.
 - `GET /api/search/observations?query=thinkoff&limit=3` returned `200` on `2026-03-31` (claude-mem path unchanged since v0.5.0).
+
+## Peer wake (same-machine agents revive sleeping colleagues)
+
+Pollers and webhooks wake an agent whose receiver is running. But when an agent's
+IDE goes quiet — the session wedged, the tunnel died silently, the app lost focus —
+nothing is listening to wake it. **Peer wake** closes that gap: a watchdog running
+in the always-on layer of a machine can revive any agent whose IDE lives on the
+**same machine**, driving its GUI directly with no network dependency.
+
+`scripts/team-watchdog.mjs` is that watchdog. Every interval it reads the room,
+computes each roster agent's last-seen timestamp, and for anyone that has gone
+quiet past `STALE_MIN` it fires exactly one wake path — rate-limited by a cooldown
+and an `MAX_NUDGES` cap so it never spams.
+
+**The model — who can wake whom:**
+
+```
+machine M (always-on watchdog)
+  ├─ localWake  → agent's IDE is ON machine M      → GUI-wake it directly,
+  │                                                   works even with no network
+  ├─ gate       → agent is on ANOTHER machine       → POST <gate>/wake to its
+  │                                                   daemon — only lands if that
+  │                                                   machine is awake + receiver up
+  └─ (neither)  → gateless agent in the room         → room @mention its poller catches
+```
+
+A watchdog only *directly* revives agents whose IDE runs on its own machine
+(`localWake`). Cross-machine wake (`gate`, the same primitive as the
+[`wake_remote` MCP tool](#whats-new-in-v070)) still needs the target machine
+awake and its receiver alive — a laptop that is *asleep* cannot be woken over the
+network without Wake-on-LAN. That is the one thing peer wake cannot do; run a
+watchdog **on each machine** so every agent has a local reviver.
+
+**Roster format** — `config/watchdog-roster.json` (gitignored; it holds hosts and
+machine paths). Copy [`config/watchdog-roster.example.json`](config/watchdog-roster.example.json)
+and edit it for the agents that live on *this* machine. Each entry names one wake path:
+
+```json
+[
+  { "handle": "@codex-on-this-mac",  "localWake": "/abs/path/ide-agent-kit/tools/codex_gui_nudge.sh" },
+  { "handle": "@agent-elsewhere",    "gate": "http://192.168.0.9:8788" },
+  { "handle": "@gateless-agent" }
+]
+```
+
+The roster can also come from `IAK_WATCHDOG_ROSTER` (inline JSON) or
+`IAK_WATCHDOG_ROSTER_FILE`. No roster → nothing to watch (the watchdog logs and
+idles), so it is safe to run everywhere.
+
+**Safety: never types over a human.** `localWake` GUI-types into the target app,
+so every wake script the watchdog invokes routes through
+[`tools/human-idle-guard.sh`](tools/human-idle-guard.sh): it refuses to inject
+keystrokes unless the machine has been idle past `IDLE_THRESHOLD_S` (default 60s),
+**fails closed** when idle state is unknown, and `--wait`s for an idle window
+rather than dropping the nudge. The shipped wake scripts (`scripts/claude-gui-wake.sh`,
+`tools/codex_gui_nudge.sh`) already call it (and also refuse to type into a locked
+screen or a non-frontmost window). **Any custom script you point `localWake` at
+MUST be idle-guarded too** — the watchdog runs it verbatim.
+
+**Opt-in install (per machine).** The watchdog is off by default — it needs a
+roster. Load it with launchd from the parameterized example:
+
+```bash
+# 1. create your roster from the example
+sed "s|REPLACE_WITH_IAK_ROOT|$HOME/ide-agent-kit|g" \
+  config/watchdog-roster.example.json > config/watchdog-roster.json
+#    then edit handles/paths for the agents whose IDEs run on THIS Mac
+
+# 2. install + load the LaunchAgent (KeepAlive; restarts if it exits)
+sed "s|REPLACE_WITH_IAK_ROOT|$HOME/ide-agent-kit|g" \
+  examples/team-watchdog-launchd.plist \
+  > ~/Library/LaunchAgents/com.thinkoff.iak-team-watchdog.plist
+launchctl load ~/Library/LaunchAgents/com.thinkoff.iak-team-watchdog.plist
+```
+
+Or let the installer do it: `IAK_INSTALL_WATCHDOG=1` makes `scripts/install.sh`
+install the LaunchAgent (only if a roster exists). On a laptop that sleeps, prefer
+the one-shot variant documented in the plist header (`ONCE=1` + `StartInterval`),
+since the in-process interval timer stalls across sleep. Tunables (all env, all
+optional): `STALE_MIN`, `COOLDOWN_MIN`, `INTERVAL_MIN`, `MAX_NUDGES`, `ROOM`,
+`WATCHDOG_SELF`, `DRY_RUN` (detect + log only, no wakes/posts).
 
 ## Integrations
 

--- a/config/watchdog-roster.example.json
+++ b/config/watchdog-roster.example.json
@@ -1,0 +1,17 @@
+[
+  {
+    "handle": "@codex-on-this-mac",
+    "localWake": "REPLACE_WITH_IAK_ROOT/tools/codex_gui_nudge.sh"
+  },
+  {
+    "handle": "@claude-on-this-mac",
+    "localWake": "REPLACE_WITH_IAK_ROOT/scripts/claude-gui-wake.sh"
+  },
+  {
+    "handle": "@agent-on-another-machine",
+    "gate": "http://REPLACE_WITH_PEER_HOST:8788"
+  },
+  {
+    "handle": "@gateless-agent-in-the-room"
+  }
+]

--- a/examples/team-watchdog-launchd.plist
+++ b/examples/team-watchdog-launchd.plist
@@ -45,6 +45,8 @@
     <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
     <key>IAK_ROOT</key>
     <string>REPLACE_WITH_IAK_ROOT</string>
+    <key>IAK_CONFIG</key>
+    <string>REPLACE_WITH_IAK_ROOT/ide-agent-kit.json</string>
   </dict>
   <key>RunAtLoad</key>
   <true/>

--- a/examples/team-watchdog-launchd.plist
+++ b/examples/team-watchdog-launchd.plist
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  launchd wiring for the peer-wake team-watchdog (opt-in, one per machine).
+
+  The watchdog is the ALWAYS-ON layer that revives sleeping colleagues: every
+  interval it reads the room and, for any roster agent that has gone quiet, runs
+  its wake path (same-machine localWake GUI nudge, cross-machine gate POST, or a
+  room @mention). See README "Peer wake" and config/watchdog-roster.example.json.
+
+  Install (launchd cannot expand $HOME, so bake the checkout path in with sed):
+    mkdir -p ~/Library/LaunchAgents
+    sed "s|REPLACE_WITH_IAK_ROOT|$HOME/ide-agent-kit|g" \
+      examples/team-watchdog-launchd.plist \
+      > ~/Library/LaunchAgents/com.thinkoff.iak-team-watchdog.plist
+    launchctl load ~/Library/LaunchAgents/com.thinkoff.iak-team-watchdog.plist
+
+  Prereq: a real roster at REPLACE_WITH_IAK_ROOT/config/watchdog-roster.json
+  (copy config/watchdog-roster.example.json and sed the same path in). The real
+  roster is gitignored — never commit hosts or machine paths.
+
+  KeepAlive restarts the long-running loop if it exits. On a LAPTOP that sleeps,
+  the in-process interval timer stalls across sleep; prefer the one-shot variant
+  instead — set ONCE=1 in EnvironmentVariables and swap KeepAlive for:
+    <key>StartInterval</key><integer>300</integer>
+  so launchd re-runs a single tick every 5 minutes regardless of sleep/wake.
+
+  Optional EnvironmentVariables (see scripts/team-watchdog.mjs header): ROOM,
+  STALE_MIN, COOLDOWN_MIN, INTERVAL_MIN, MAX_NUDGES, WATCHDOG_SELF, DRY_RUN,
+  GROUPMIND_KEY. If GROUPMIND_KEY is unset it is read from config (poller.api_key).
+-->
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.thinkoff.iak-team-watchdog</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/bash</string>
+    <string>-c</string>
+    <string>cd REPLACE_WITH_IAK_ROOT &amp;&amp; exec node scripts/team-watchdog.mjs</string>
+  </array>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PATH</key>
+    <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    <key>IAK_ROOT</key>
+    <string>REPLACE_WITH_IAK_ROOT</string>
+  </dict>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <true/>
+  <key>ThrottleInterval</key>
+  <integer>30</integer>
+  <key>StandardOutPath</key>
+  <string>/tmp/iak-team-watchdog.launchd.log</string>
+  <key>StandardErrorPath</key>
+  <string>/tmp/iak-team-watchdog.launchd.log</string>
+</dict>
+</plist>

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -150,6 +150,35 @@ tmux new-session -d -s "$TMUX_SESSION" \
   "cd $INSTALL_DIR && node bin/iak-mcp-daemon.mjs"
 sleep 2
 
+# 6b. Optional: peer-wake team-watchdog (opt-in; needs a roster).
+# OFF by default — enable with IAK_INSTALL_WATCHDOG=1. Revives sleeping
+# colleagues whose IDEs run on THIS machine; see README "Peer wake".
+if [ "${IAK_INSTALL_WATCHDOG:-0}" = "1" ]; then
+  ROSTER_FILE="$INSTALL_DIR/config/watchdog-roster.json"
+  if [ ! -f "$ROSTER_FILE" ]; then
+    yellow "IAK_INSTALL_WATCHDOG=1 but no roster at $ROSTER_FILE — skipping."
+    echo "  Create one from the example, then re-run with IAK_INSTALL_WATCHDOG=1:"
+    echo "    sed \"s|REPLACE_WITH_IAK_ROOT|$INSTALL_DIR|g\" \\"
+    echo "      $INSTALL_DIR/config/watchdog-roster.example.json > $ROSTER_FILE"
+    echo "    # then edit handles/paths for the agents whose IDEs run on THIS Mac"
+  else
+    LA_DIR="$HOME/Library/LaunchAgents"
+    PLIST="$LA_DIR/com.thinkoff.iak-team-watchdog.plist"
+    mkdir -p "$LA_DIR"
+    sed "s|REPLACE_WITH_IAK_ROOT|$INSTALL_DIR|g" \
+      "$INSTALL_DIR/examples/team-watchdog-launchd.plist" > "$PLIST"
+    yellow "Installed peer-wake watchdog LaunchAgent → $PLIST"
+    if launchctl list 2>/dev/null | grep -q com.thinkoff.iak-team-watchdog; then
+      echo "  Already loaded. Reload after edits:"
+      echo "    launchctl unload \"$PLIST\" && launchctl load \"$PLIST\""
+    elif launchctl load "$PLIST" 2>/dev/null; then
+      green "  Loaded (KeepAlive; reads $ROSTER_FILE)."
+    else
+      yellow "  Load it manually: launchctl load \"$PLIST\""
+    fi
+  fi
+fi
+
 # 7. report
 LAN_IP=$(ipconfig getifaddr en0 2>/dev/null || ipconfig getifaddr en1 2>/dev/null || echo "127.0.0.1")
 LAN_URL="http://${LAN_IP}:8788"

--- a/scripts/team-watchdog.mjs
+++ b/scripts/team-watchdog.mjs
@@ -32,8 +32,27 @@ const REPO  = process.env.IAK_ROOT || new URL('..', import.meta.url).pathname.re
 let _key;
 function KEY() {
   if (_key === undefined) {
-    _key = process.env.GROUPMIND_KEY || process.env.ANTFARM_KEY
-      || JSON.parse(readFileSync(process.env.IAK_CONFIG || `${REPO}/config/macbook.json`, 'utf8')).poller.api_key;
+    // Resolve the key from env, else the config the installer actually writes
+    // (ide-agent-kit.json), falling back to the legacy config/macbook.json so
+    // existing hand-wired setups keep working (codex review, #34: the opt-in
+    // install only sets IAK_ROOT, so a macbook.json-only default threw every
+    // tick on a fresh install).
+    if (process.env.GROUPMIND_KEY || process.env.ANTFARM_KEY) {
+      _key = process.env.GROUPMIND_KEY || process.env.ANTFARM_KEY;
+    } else {
+      const candidates = [
+        process.env.IAK_CONFIG,
+        `${REPO}/ide-agent-kit.json`,
+        `${REPO}/config/macbook.json`,
+      ].filter(Boolean);
+      let found;
+      for (const c of candidates) {
+        try { found = JSON.parse(readFileSync(c, 'utf8'))?.poller?.api_key; } catch { /* next */ }
+        if (found) break;
+      }
+      if (!found) throw new Error(`team-watchdog: no GROUPMIND_KEY and no poller.api_key in ${candidates.join(', ')}`);
+      _key = found;
+    }
   }
   return _key;
 }

--- a/scripts/team-watchdog.mjs
+++ b/scripts/team-watchdog.mjs
@@ -1,22 +1,42 @@
 #!/usr/bin/env node
-// team-watchdog (claudeMB / MacBook) — keep the team alive in the room.
+// team-watchdog — peer-wake watchdog: keep the team alive in the room.
 //
 // Runs in the ALWAYS-ON layer (launchd / tmux), independent of any agent IDE.
 // Every INTERVAL it reads the room, computes each roster agent's last-seen, and
-// wakes any that has gone quiet too long: POST <gate>/wake (if reachable) + an
-// @mention nudge their poller catches. Rate-limited so it never spams.
+// wakes any that has gone quiet too long. Each roster entry picks ONE wake path:
+//   - localWake: a SAME-MACHINE GUI wake script (idle-guarded) — the watchdog
+//     on machine M can revive any agent whose IDE runs on M, even with no
+//     network reachability. This is the "same-machine peer wake" primitive.
+//   - gate: a cross-machine POST <gate>/wake to a peer daemon (reachable only
+//     while that machine is awake and its receiver is running).
+//   - neither: a room @mention nudge the agent's own poller catches.
+// Rate-limited (cooldown + MAX_NUDGES) so it never spams the room.
 //
-// DRY_RUN=1  -> detect + log only, NO room posts / wakes (safe before Tailscale
-//               to the Mini is up, since unreachable agents would just get spam).
-// Flip to active (unset DRY_RUN) once `tailscale up` is done on the Mini.
+// localWake targets MUST be idle-guarded scripts (they call tools/human-idle-guard.sh
+// so they never type over an active human). The repo's claude-gui-wake.sh and
+// tools/codex_gui_nudge.sh already do; any custom script you point localWake at must too.
 //
-// Env: ANTFARM_KEY (defaults to claudeMB posting key), ROOM, STALE_MIN,
-//      COOLDOWN_MIN, INTERVAL_MIN, MAX_NUDGES.
+// DRY_RUN=1  -> detect + log only, NO room posts / wakes (safe while peers are
+//               unreachable, since they would otherwise just get spam).
+//
+// Env: GROUPMIND_KEY (or legacy ANTFARM_KEY), ROOM, STALE_MIN, COOLDOWN_MIN,
+//      INTERVAL_MIN, MAX_NUDGES, WATCHDOG_SELF. Roster: IAK_WATCHDOG_ROSTER
+//      (inline JSON) or IAK_WATCHDOG_ROSTER_FILE (default config/watchdog-roster.json).
 
-const API   = 'https://antfarm.world/api/v1';
+// Every call site uses groupmind.one; antfarm.world is the dead legacy host.
+export const API = 'https://groupmind.one/api/v1';
 const HOME  = process.env.HOME || '';
 const REPO  = process.env.IAK_ROOT || new URL('..', import.meta.url).pathname.replace(/\/$/, '');
-const KEY   = process.env.ANTFARM_KEY || JSON.parse(readFileSync(process.env.IAK_CONFIG || `${REPO}/config/macbook.json`,'utf8')).poller.api_key;
+// Resolved lazily so importing this module (e.g. from a test) never touches the
+// config file. GROUPMIND_KEY is the current name; ANTFARM_KEY stays as a legacy alias.
+let _key;
+function KEY() {
+  if (_key === undefined) {
+    _key = process.env.GROUPMIND_KEY || process.env.ANTFARM_KEY
+      || JSON.parse(readFileSync(process.env.IAK_CONFIG || `${REPO}/config/macbook.json`, 'utf8')).poller.api_key;
+  }
+  return _key;
+}
 const ROOM  = process.env.ROOM || 'thinkoff-development';
 const DRY   = process.env.DRY_RUN === '1';
 const STALE_MS    = (Number(process.env.STALE_MIN)    || 20) * 60_000;
@@ -28,7 +48,7 @@ const MAX_NUDGES  = Number(process.env.MAX_NUDGES) || 2;   // stop room-posting 
 // it - silence is an accepted state. Only a gateless agent (room @mention is its
 // wake path) or an UNREACHABLE gate produces a room post.
 
-const SELF = 'claudemb';
+const SELF = process.env.WATCHDOG_SELF || 'claudemb';
 // ether + hermes are set to mention_only (Jul 5 2026, after the overnight
 // flood): the ONLY thing that makes them talk is being @mentioned, so a
 // watchdog nudge to them re-creates the exact noise petrus complained about.
@@ -37,7 +57,7 @@ const SELF = 'claudemb';
 // hardcode tailnet IPs or machine paths (#30 gate, B3). File format:
 // config/watchdog-roster.json = [{"handle":"@x","gate":"http://host:8788"},
 // {"handle":"@y","localWake":"/abs/path.sh"}]
-function loadRoster() {
+export function loadRoster() {
   const fromEnv = process.env.IAK_WATCHDOG_ROSTER;
   const file = process.env.IAK_WATCHDOG_ROSTER_FILE || `${REPO}/config/watchdog-roster.json`;
   try {
@@ -48,7 +68,7 @@ function loadRoster() {
     return [];
   }
 }
-const ROSTER = loadRoster();
+let ROSTER = [];
 /* Historical roster notes (Jul 2026):
   // codex ADDED with a silent LOCAL wake (Jul 13 2026): its webhook-wake tunnel
   // died silently Jul 9-12 and nobody noticed for three days. The watchdog is
@@ -64,21 +84,22 @@ const ROSTER = loadRoster();
 // State persists to a file so it survives one-shot (StartInterval) runs and
 // sleep/wake. In-process setTimeout pauses when the Mac sleeps, so the watchdog
 // runs as a launchd StartInterval one-shot (ONCE=1) instead of a long loop.
-import { readFileSync, writeFileSync } from 'node:fs';
+import { readFileSync, writeFileSync, realpathSync } from 'node:fs';
 import { execFile } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
 const STATE_FILE = '/tmp/team-watchdog-state.json';
 let state = {};
-try { state = JSON.parse(readFileSync(STATE_FILE, 'utf8')); } catch {}
+function loadState() { try { return JSON.parse(readFileSync(STATE_FILE, 'utf8')); } catch { return {}; } }
 function saveState() { try { writeFileSync(STATE_FILE, JSON.stringify(state)); } catch {} }
 
 async function getMessages() {
-  const r = await fetch(`${API}/rooms/${ROOM}/messages?limit=80`, { headers: { 'X-API-Key': KEY }, signal: AbortSignal.timeout(15000) });
+  const r = await fetch(`${API}/rooms/${ROOM}/messages?limit=80`, { headers: { 'X-API-Key': KEY() }, signal: AbortSignal.timeout(15000) });
   const d = await r.json();
   return d.messages || [];
 }
 async function postRoom(body) {
   if (DRY) { console.log('[dry] would post:', body); return; }
-  await fetch(`${API}/messages`, { method: 'POST', headers: { 'X-API-Key': KEY, 'Content-Type': 'application/json' }, body: JSON.stringify({ room: ROOM, body }), signal: AbortSignal.timeout(15000) });
+  await fetch(`${API}/messages`, { method: 'POST', headers: { 'X-API-Key': KEY(), 'Content-Type': 'application/json' }, body: JSON.stringify({ room: ROOM, body }), signal: AbortSignal.timeout(15000) });
 }
 async function wakeGate(gate) {
   if (!gate) return false;
@@ -115,7 +136,7 @@ function wakeLocal(script) {
     }, (err) => resolve(!err));
   });
 }
-function lastSeen(msgs, handle) {
+export function lastSeen(msgs, handle) {
   const h = handle.replace(/^@/, '').toLowerCase();
   let t = 0;
   for (const m of msgs) {
@@ -126,6 +147,14 @@ function lastSeen(msgs, handle) {
   }
   return t;
 }
+// Pure staleness helpers (exported for unit tests). `seen` is the epoch-ms
+// timestamp from lastSeen(); 0 means "never seen" -> infinitely stale.
+export function ageMinutes(seen, now) {
+  return seen ? Math.round((now - seen) / 60000) : Infinity;
+}
+export function isStale(seen, now, staleMs) {
+  return (now - (seen || 0)) > staleMs;
+}
 
 async function tick() {
   const msgs = await getMessages();
@@ -133,9 +162,9 @@ async function tick() {
   const toNudge = [];
   for (const a of ROSTER) {
     const seen = lastSeen(msgs, a.handle);
-    const ageMin = seen ? Math.round((now - seen) / 60000) : Infinity;
+    const ageMin = ageMinutes(seen, now);
     const st = (state[a.handle] ||= { lastNudge: 0, misses: 0, silentWakes: 0 });
-    const stale = (now - (seen || 0)) > STALE_MS;
+    const stale = isStale(seen, now, STALE_MS);
     if (!stale) { st.misses = 0; st.silentWakes = 0; continue; }
     if (now - st.lastNudge < COOLDOWN_MS) continue;      // rate-limit
     if (st.misses >= MAX_NUDGES) { console.log(`${a.handle} still down (giving room a rest after ${st.misses} nudges)`); continue; }
@@ -172,17 +201,28 @@ async function tick() {
   if (toNudge.length) {
     const mentions = toNudge.map(n => n.handle).join(' ');
     const detail = toNudge.map(n => `${n.handle} quiet ${n.ageMin}m${n.wedged ? ' [gate woke but no post - possibly wedged]' : ''}`).join(', ');
-    await postRoom(`${mentions} [team-watchdog] you have gone quiet - check rooms and reply here. (${detail}; auto from claudeMB)`);
+    await postRoom(`${mentions} [team-watchdog] you have gone quiet - check rooms and reply here. (${detail}; auto from ${SELF})`);
   }
   saveState();
   console.log(new Date().toISOString(), `checked ${ROSTER.length}`, toNudge.length ? `nudged: ${toNudge.map(n=>n.handle).join(',')}` : 'all healthy/cooling');
 }
 
-(async () => {
+async function run() {
+  ROSTER = loadRoster();
+  state = loadState();
   console.log(`team-watchdog up. DRY_RUN=${DRY} stale=${STALE_MS/60000}m cooldown=${COOLDOWN_MS/60000}m interval=${INTERVAL_MS/60000}m`);
   for (;;) {
     try { await tick(); } catch (e) { console.error('tick error:', e.message); }
     if (process.env.ONCE === '1') break;
     await new Promise(r => setTimeout(r, INTERVAL_MS));
   }
+}
+
+// Only run the loop when executed directly (node scripts/team-watchdog.mjs),
+// never when imported by a test. Keeping import side-effect-free is what lets
+// the pure helpers (loadRoster, lastSeen, ageMinutes, isStale) be unit-tested.
+const invokedDirectly = (() => {
+  try { return !!process.argv[1] && realpathSync(process.argv[1]) === fileURLToPath(import.meta.url); }
+  catch { return false; }
 })();
+if (invokedDirectly) run();

--- a/test/team-watchdog.test.mjs
+++ b/test/team-watchdog.test.mjs
@@ -1,0 +1,97 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { API, lastSeen, ageMinutes, isStale, loadRoster } from '../scripts/team-watchdog.mjs';
+
+const MIN = 60_000;
+
+// Guards the stale-host regression: every call site must hit groupmind.one, not
+// the dead legacy antfarm.world host.
+test('API points at the live groupmind.one host, not antfarm.world', () => {
+  assert.equal(API, 'https://groupmind.one/api/v1');
+  assert.ok(!API.includes('antfarm.world'));
+});
+
+test('lastSeen returns the newest matching message timestamp, @/case-insensitively', () => {
+  const msgs = [
+    { from: '@Codex', created_at: '2026-07-14T00:00:00Z' },
+    { from: 'codex', created_at: '2026-07-14T01:00:00Z' }, // newer, no @, lowercase
+    { from: '@someone-else', created_at: '2026-07-14T09:00:00Z' },
+  ];
+  assert.equal(lastSeen(msgs, '@codex'), Date.parse('2026-07-14T01:00:00Z'));
+  assert.equal(lastSeen(msgs, 'CODEX'), Date.parse('2026-07-14T01:00:00Z'));
+});
+
+test('lastSeen returns 0 when the agent has never posted', () => {
+  assert.equal(lastSeen([{ from: '@other', created_at: '2026-07-14T00:00:00Z' }], '@ghost'), 0);
+  assert.equal(lastSeen([], '@anyone'), 0);
+});
+
+test('ageMinutes is Infinity for a never-seen agent and rounded minutes otherwise', () => {
+  const now = 1_000 * MIN;
+  assert.equal(ageMinutes(0, now), Infinity);
+  assert.equal(ageMinutes(now - 20 * MIN, now), 20);
+  assert.equal(ageMinutes(now - 29_000, now), 0); // <30s rounds down to 0
+});
+
+test('isStale compares age against the threshold and treats never-seen as stale', () => {
+  const now = 1_000 * MIN;
+  const staleMs = 20 * MIN;
+  assert.equal(isStale(now - 21 * MIN, now, staleMs), true);  // older than threshold
+  assert.equal(isStale(now - 19 * MIN, now, staleMs), false); // fresher than threshold
+  assert.equal(isStale(0, now, staleMs), true);               // never seen -> stale
+});
+
+test('loadRoster reads inline JSON from IAK_WATCHDOG_ROSTER', () => {
+  const prev = process.env.IAK_WATCHDOG_ROSTER;
+  try {
+    process.env.IAK_WATCHDOG_ROSTER = JSON.stringify([
+      { handle: '@codex', localWake: '/abs/path/codex_gui_nudge.sh' },
+      { handle: '@peer', gate: 'http://host:8788' },
+    ]);
+    const roster = loadRoster();
+    assert.equal(roster.length, 2);
+    assert.equal(roster[0].localWake, '/abs/path/codex_gui_nudge.sh');
+    assert.equal(roster[1].gate, 'http://host:8788');
+  } finally {
+    if (prev === undefined) delete process.env.IAK_WATCHDOG_ROSTER;
+    else process.env.IAK_WATCHDOG_ROSTER = prev;
+  }
+});
+
+test('loadRoster reads a roster file via IAK_WATCHDOG_ROSTER_FILE', () => {
+  const prevEnv = process.env.IAK_WATCHDOG_ROSTER;
+  const prevFile = process.env.IAK_WATCHDOG_ROSTER_FILE;
+  const dir = mkdtempSync(path.join(tmpdir(), 'iak-roster-'));
+  try {
+    delete process.env.IAK_WATCHDOG_ROSTER; // env inline must not shadow the file
+    const file = path.join(dir, 'roster.json');
+    writeFileSync(file, JSON.stringify([{ handle: '@gateless' }]));
+    process.env.IAK_WATCHDOG_ROSTER_FILE = file;
+    const roster = loadRoster();
+    assert.deepEqual(roster, [{ handle: '@gateless' }]);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+    if (prevEnv === undefined) delete process.env.IAK_WATCHDOG_ROSTER;
+    else process.env.IAK_WATCHDOG_ROSTER = prevEnv;
+    if (prevFile === undefined) delete process.env.IAK_WATCHDOG_ROSTER_FILE;
+    else process.env.IAK_WATCHDOG_ROSTER_FILE = prevFile;
+  }
+});
+
+test('loadRoster returns [] when the roster is missing (nothing to watch, no crash)', () => {
+  const prevEnv = process.env.IAK_WATCHDOG_ROSTER;
+  const prevFile = process.env.IAK_WATCHDOG_ROSTER_FILE;
+  try {
+    delete process.env.IAK_WATCHDOG_ROSTER;
+    process.env.IAK_WATCHDOG_ROSTER_FILE = path.join(tmpdir(), 'iak-does-not-exist-' + Date.now() + '.json');
+    assert.deepEqual(loadRoster(), []);
+  } finally {
+    if (prevEnv === undefined) delete process.env.IAK_WATCHDOG_ROSTER;
+    else process.env.IAK_WATCHDOG_ROSTER = prevEnv;
+    if (prevFile === undefined) delete process.env.IAK_WATCHDOG_ROSTER_FILE;
+    else process.env.IAK_WATCHDOG_ROSTER_FILE = prevFile;
+  }
+});


### PR DESCRIPTION
## Directive

Petrus, 2026-07-14: *"Put this in iak: agents on the same computer can wake up sleeping colleagues with computer."*

## What existed

`scripts/team-watchdog.mjs` already implemented the core mechanism: an always-on watchdog reads the room, computes each roster agent's last-seen, and for a stale agent runs a wake path — a **same-machine `localWake`** (idle-guarded GUI nudge), a cross-machine `gate` POST, or a room `@mention`. It was, however, a machine-specific one-off pointed at a dead host, unrunnable without hand-wiring, and untested.

## What this adds (the productization)

- **Stale-host fix** — the API base was `https://antfarm.world/api/v1` (dead legacy host); changed to `https://groupmind.one/api/v1`, which every other call site uses. A test asserts the constant so it can't regress.
- **Testability seam** — exported the pure helpers (`loadRoster`, `lastSeen`, `ageMinutes`, `isStale`), made key/roster/state resolution lazy, and guarded the loop to run **only when invoked directly** (`node scripts/team-watchdog.mjs`), never on import. Import is now side-effect-free. Added `test/team-watchdog.test.mjs` (8 cases: host constant, last-seen matching, staleness math, roster parsing from env / file / missing).
- **Runnable** — `examples/team-watchdog-launchd.plist`: a parameterized launchd unit (`REPLACE_WITH_IAK_ROOT` + documented `sed`, **no** hardcoded `/Users/...` paths, **no** tailnet IPs — the #30 review blocker class), `KeepAlive` true, plus the documented `ONCE=1`/`StartInterval` one-shot variant for laptops that sleep (the in-process timer stalls across sleep).
- **Roster scaffold** — `config/watchdog-roster.example.json` with placeholder handles/paths showing all three entry types. The real `config/watchdog-roster.json` stays gitignored (`config/*.json`).
- **Opt-in install** — a guarded step in `scripts/install.sh` (`IAK_INSTALL_WATCHDOG=1`, roster-gated, **off by default**) + a README **"Peer wake"** section documenting the model, roster format, safety, and install.

## Idle-guard safety guarantee

`localWake` GUI-types into the target app, so every wake script the watchdog invokes routes through `tools/human-idle-guard.sh`: it refuses to inject keystrokes unless the machine has been idle past `IDLE_THRESHOLD_S` (default 60s), **fails closed** when idle state is unknown, and `--wait`s for an idle window rather than dropping the nudge. The shipped `scripts/claude-gui-wake.sh` and `tools/codex_gui_nudge.sh` already call it (and also refuse a locked screen / non-frontmost window); the docs require any custom `localWake` target to as well. **No keystroke-over-human risk is reintroduced.**

## The model (and its one limit)

A watchdog *directly* revives only agents whose IDE runs on **its own machine** (`localWake`) — this works even with no network. Cross-machine wake (`gate`, the `wake_remote` primitive) still needs the target machine **awake** with its receiver alive. A laptop that is *asleep* cannot be woken over the network without Wake-on-LAN — run a watchdog on each machine so every agent has a local reviver.

## Tests

`npm test` → **128/128 pass** (120 prior + 8 new). `node --check scripts/team-watchdog.mjs`, `bash -n scripts/install.sh`, and `plutil -lint` on the plist all clean.

## Review

@codexmb — requesting an adversarial review per the cross-model rule before merge. You're a primary consumer here: the MacBook watchdog's `localWake` path revives `@codexmb` when its webhook tunnel dies (the Jul 9-12 silent-death case this backstops). Please poke especially at the idle-guard contract for `localWake` targets and the direct-invocation guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)