### PR TITLE
docs(README): refresh What's new to v0.10.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,34 +15,11 @@ LAN URL to paste into CodeWatch — the upcoming mobile + watch companion app.
 **Manual install:** `npm install -g ide-agent-kit`
 **ClawHub:** https://clawhub.ai/ThinkOffApp/ide-agent-kit
 
-## What's new in v0.7.0
+## What's new in v0.10.0
 
-- **MCP server** (`src/mcp-server.mjs`): exposes IAK as MCP tools to any
-  Claude Code / Codex / Cursor agent. Tools: `wake_ide`, `wake_all`,
-  `wake_remote` (cross-machine), `request_confirmation`, `tmux_run`,
-  `read_session`, `list_intents`, `approve_intent`, `deny_intent`.
-- **Confirmation registry** (`iak-mcp-daemon`): HTTP server on port 8788
-  with `POST /intent`, `GET /intents`, `POST /intent/<id>/decision`,
-  `POST /wake`. Browser UI at `/` with Approve/Deny buttons that work on
-  Wear OS, phone, and Mac.
-- **wake_remote MCP tool**: cross-machine direct nudge. Agent A on the
-  MacBook calls `wake_remote(gateUrl="http://<mini>:8788")`; mini's
-  daemon spawns the wake script and the mini's Claude desktop app
-  receives a prompt within ~500ms.
-- **CodeWatch integration** *(upcoming companion app)*: an Android
-  phone + Wear OS app that surfaces confirmation requests inline in
-  the IDE chat with Approve/Deny buttons, plus system notifications
-  with action buttons. Coming soon to the Play Store.
-- **GroupMind chat buttons**: confirmation messages render inline
-  Approve/Deny buttons in the GroupMind web UI (antfarm PR #13 merged).
-- **Auto-wake suite**: `claudemb-poll.sh` (room poller) +
-  `claudemb-wake.sh` (osascript injector, focus-preserving) +
-  `claudecode-stop-resume.sh` (Stop hook, no Accessibility required) +
-  `check-rooms-hook.sh` (UserPromptSubmit hook). Full setup docs in
-  `docs/auto-wake.md` with ASCII diagram and troubleshooting.
-- **76 / 76 tests passing** on Node 18, 20, 22.
+The "never type over the human" release. A fail-closed idle guard now gates every keystroke a wake can inject, so agents never garble your typing; deferred wakes retry instead of dropping messages; and room_ack only clears what it read. First release since June, hardened by cross-model review on every change.
 
-[Release notes →](https://github.com/ThinkOffApp/ide-agent-kit/releases/tag/v0.7.0)
+[Release notes →](https://github.com/ThinkOffApp/ide-agent-kit/releases/tag/v0.10.0)
 
 ## Table of Contents
 


### PR DESCRIPTION
Petrus-approved (B) in thinkoff-development. The README What's new block was stale at v0.7.0; this updates it to the shipped v0.10.0 with the current release-notes link. Docs-only. @codexmb quick review welcome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)