### PR TITLE
fix: codex webhook receiver launched without env, crash-looping on missing secret

### DIFF
--- a/scripts/codex-webhook-supervisor.sh
+++ b/scripts/codex-webhook-supervisor.sh
@@ -44,6 +44,11 @@ receiver_running(){
 }
 start_receiver(){
   receiver_running || {
+    # NODE_BIN must be resolved on its own line: if it sits at the end of the
+    # env-assignment chain, the whole chain becomes an assignment-only
+    # statement and node launches with NO env (receiver exits on missing
+    # WEBHOOK_WAKE_SECRET, crash-looping every cycle).
+    NODE_BIN="$(command -v node || echo /usr/local/bin/node)"
     WEBHOOK_WAKE_SECRET="$SECRET" \
     WEBHOOK_WAKE_PORT="$PORT" \
     WEBHOOK_WAKE_SCRIPT="$WAKE" \
@@ -53,7 +58,6 @@ start_receiver(){
     WEBHOOK_WAKE_LOG="/tmp/codex-webhook-wake.log" \
     IAK_CODEX_APP_NAME="ChatGPT" \
     IAK_NUDGE_TEXT="check rooms [codex]" \
-      NODE_BIN="$(command -v node || echo /usr/local/bin/node)"
       "$NODE_BIN" "$RECEIVER" >>/tmp/codex-webhook-wake.log 2>&1 &
       sleep 1
       if kill -0 $! 2>/dev/null; then log "receiver started"; else log "receiver FAILED to start"; fi


### PR DESCRIPTION
## Problem
`start_receiver` in `scripts/codex-webhook-supervisor.sh` builds a backslash-continuation chain of `WEBHOOK_WAKE_*` env assignments that ends with `NODE_BIN=$(command -v node ...)` on its own continuation line. That makes the entire chain an **assignment-only statement**: the variables become plain shell variables of the supervisor and are never exported. The node receiver is then launched on the *next* line with none of them set, so `webhook-wake.mjs` exits code 2 on the missing `WEBHOOK_WAKE_SECRET` and the supervisor relaunches it every 30s.

Net effect: @codexmb's low-latency wake webhook has been dead the whole time (log full of `WEBHOOK_WAKE_SECRET missing or too short`), and codex only woke via the slow poller. The claudemb twin (`webhook-supervisor.sh`) never had the bug because its env prefix sits on the same line as the node invocation.

## Fix
Resolve `NODE_BIN` on its own line first, keep the env-assignment prefix attached to the node command. Comment added so the next edit doesn't reintroduce it.

## Verification (live on the MB)
- `launchctl kickstart -k gui/501/com.thinkoff.codex-webhook-supervisor`
- receiver up: `webhook-wake listening on 127.0.0.1:8791`, node LISTENing on :8791
- tunnel registered with GroupMind: http 200
- POST to `/hook/<secret>` returns 200; non-owner/self payload correctly skipped (`skip: not owner/mention`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)