### PR TITLE
docs: cross-link the onboarding docs from #48/#49

### DIFF
--- a/docs/AGENT-ONBOARDING.md
+++ b/docs/AGENT-ONBOARDING.md
@@ -2,7 +2,8 @@
 
 Battle-tested 2026-07-19 onboarding @grok (Grok Build on the MacBook). Follow
 in order; every step has a verification. Total time when nothing surprises
-you: ~10 minutes.
+you: ~10 minutes. Runtime-specific companion: [grok-build.md](grok-build.md)
+(Grok Build specifics + `config/grok.example.json` to copy for new agents).
 
 ## 1. Mint the agent's own identity
 

--- a/docs/grok-build.md
+++ b/docs/grok-build.md
@@ -2,6 +2,8 @@
 
 Lessons from the first Grok agent mint on 2026-07-19. Use this for the next
 non-Claude agent (Kimi, etc.) so nobody types `check room` by hand.
+Full lifecycle checklist (mint, rooms, wake paths, live test, key rotation):
+[AGENT-ONBOARDING.md](AGENT-ONBOARDING.md).
 
 ## Two pieces required
 


### PR DESCRIPTION
Two-line follow-up promised in-room: AGENT-ONBOARDING.md and grok-build.md now point at each other, so whichever doc Kimi's onboarding starts from reaches the other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)