### PR TITLE
gitignore: cover config/*.env, which the .json rule never did

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,14 @@ data/*.json
 config/*.json
 config/*.bak*
 *.bak.*
+# ...and so do the .env variants, which config/*.json above does NOT cover
+# and the bare `.env` rule above does not either (that matches a file named
+# exactly ".env", not "grok.env"). Found on the MacBook 2026-08-03: an
+# unignored config/grok.env holding a live key, one `git add -A` away from
+# a PUBLIC repo - the same leak as 2026-07-09, through the sibling nobody
+# added a rule for.
+*.env
+config/*.env
 # Per-agent poller configs hold live API keys - never commit (leaked 2026-07-09)
 gemini-config.json
 gemini-config.json.bak*


### PR DESCRIPTION
## What

`config/*.env` and `*.env` added to `.gitignore`.

## Why, and it is not hypothetical

Checking my own IAK checkout after @claudemm flagged local patches on the Mini, I found **`config/grok.env` — untracked, unignored, holding a live key, in a clone of a repo that is public.** One `git add -A` commits it. That is exactly the 2026-07-09 leak, which we already paid for once in a key rotation.

**Neither existing rule covered it:**

- `config/*.json` is scoped to JSON. The `.env` file sat right beside the files that rule protects.
- The bare `.env` rule matches a file named *exactly* `.env`. It does not match `grok.env`.

So the block whose own comment reads *"Local machine configs hold live API keys - never commit"* was protecting one extension in that directory and silently not the other.

## The pattern, because we hit it twice today

This is the sibling trap. A rule gets written for one variant, the variant it was written against stays correct, and nobody checks the neighbour. The other instance today was in CodeWatch: `thinkoff_green` was corrected for the light theme and its near-twin `thinkoff_green_light` kept the dark value, shipping 21 call sites at 2.6:1 for weeks. Same shape, different file.

Worth a habit: when adding a protective rule, ask what *else* lives in the directory it protects.

## Verified by execution, not by reading

```
$ git check-ignore -v config/grok.env
.gitignore:21:config/*.env	config/grok.env
```

Created the real filename in a worktree, confirmed the rule resolves to it, removed it again.

## Why a PR and not a local exclude

I have already closed the hole on my own machine via `.git/info/exclude`, so nothing is urgent for me. But that fixes it for exactly one of us. Any user who drops a per-agent `.env` into `config/` — which is the natural place to put it, next to the `.json` configs we tell them to put there — has the same exposure right now. Per the dogfood directive this belongs in the product with a working default, not in my checkout.

**Not touched:** the local modifications and stashes on the Mini that @claudemm flagged, and the ones on my own checkout (`scripts/codex-webhook-supervisor.sh`, a one-line diff, plus a WIP stash). Those need a look at what they actually do and are @petrus's call — one of them backs a running process.