### PR TITLE
A live key was sitting in an unignored log; .bak files were unignored too

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,20 @@ config/*.bak*
 gemini-config.json
 gemini-config.json.bak*
 scripts/__pycache__/
+
+# Backup copies of edited files. The `*.bak.*` rule above requires a dot
+# AFTER "bak", so it matches "foo.bak.1" and silently does NOT match a plain
+# "foo.bak" outside config/. Found 2026-08-03: 14 such files sitting untracked
+# in a clone of this PUBLIC repo, one `git add -A` from being published. The
+# cp-before-edit habit is a good one; it just needs the ignore rules to match
+# the names it actually produces.
+*.bak
+*.bak_*
+*-bak
+*-bak.*
+
+# Run logs. `*.log` above does not cover them, because start-all writes .out.
+# A log is a plausible place for a key to land: the file that prompted this
+# was logs/start-all.out on the Mini, which contained a live xfb_ agent key.
+logs/
+*.out


### PR DESCRIPTION
Found on the Mini while checking it for the hole [#55](https://github.com/ThinkOffApp/ide-agent-kit/pull/55) found on the MacBook. Different file, same shape.

## A live key was in an untracked file

`logs/start-all.out` was untracked, unignored, and **contained a live `xfb_` agent key**. `*.log` did not cover it because `start-all` writes `.out`. This is a clone of a **public** repo, so one `git add -A` publishes it.

Alongside it, **14 backup files** were equally unignored:

```
README.md.bak                              CHANGELOG.md.bak
bin/cli.mjs.bak                            src/config.mjs.bak
src/background.mjs.bak                     src/actions.mjs.parallel-bak
src/confirmations.mjs.bak_20260704-183213  src/confirmations.mjs.live-bak.20260621
scripts/start-all.sh.bak_prehardening_20260709   ...and 5 more
```

The existing `*.bak.*` rule requires a dot **after** `bak`. So it matches `foo.bak.1` and silently does *not* match plain `foo.bak` anywhere outside `config/`. The cp-before-edit habit that produced these is a good one — it is the ignore rules that never matched the names it actually produces.

## Verification

Tested against the **real filenames found on disk**, not invented ones. All 15 are now ignored:

| file | rule |
|---|---|
| `README.md.bak` | `*.bak` |
| `scripts/claude-gui-wake.sh.bak_20260707` | `*.bak_*` |
| `src/actions.mjs.parallel-bak` | `*-bak` |
| `src/confirmations.mjs.live-bak.20260621` | `*-bak.*` |
| `logs/start-all.out` | `logs/` |
| `foo.bak.1` | `*.bak.*` (existing rule, still works) |

And confirmed **not** caught: `src/confirmations.mjs`, `README.md`, `package.json`, `bin/cli.mjs`.

## Independent of #55

Deliberately **appended** rather than edited in place, leaving the existing config block untouched, so this does not collide with #55's `config/*.env` insertion. The two PRs are independent and merge in either order — verified by keeping my diff to pure additions at the end of the file.

## The pattern, three times in one day

This is the third instance of one defect shape: **a rule written for one variant, correct for that variant, never extended to its neighbour.**

1. CodeWatch: `thinkoff_green` corrected to a light value while `thinkoff_green_light` kept the dark one, across 21 call sites.
2. IAK: `config/*.json` protecting `.json` in that directory but not `.env`.
3. IAK: `*.bak.*` protecting `foo.bak.1` but not `foo.bak`.

In all three the original rule stayed correct, so nothing failed where anyone was looking. Worth a habit: when writing a rule that names a variant, ask what its siblings are called.

## Not addressed here

`scripts/claudemm-uik-daemon.sh` is untracked in the Mini clone and contains machine-specific paths. It should not live in this repo at all, but removing it is petrus's call and not a `.gitignore` matter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
