### PR TITLE
Owner identities are configured, because a person is not one handle

### DIFF
--- a/bin/iak-mcp-daemon.mjs
+++ b/bin/iak-mcp-daemon.mjs
@@ -86,6 +86,9 @@ if (!apiKey) {
 } else {
   startChatReplyPoller({
     apiKey, room, intervalMs: 5000,
+    // Owner identities that may settle intents. A person is not one handle:
+    // petrus posts from a web session, a tablet and (soon) a watch.
+    owners: cc.owners,
     log: (msg) => console.log(`[iak-mcp-daemon] ${msg}`),
   });
   console.log(`[iak-mcp-daemon] chat-reply poller watching room "${room}" every 5s`);

--- a/src/confirmations.mjs
+++ b/src/confirmations.mjs
@@ -1065,11 +1065,20 @@ export function composeAnnouncers(map) {
 //
 // Logs go to stderr only (stdout is the MCP stdio protocol channel — writing
 // there would corrupt it). Returns the interval handle so callers can stop it.
-export function startChatReplyPoller({ apiKey, room, intervalMs = 5000, log }) {
+// `owners` is an EXPLICIT list of handles allowed to settle intents. It is a
+// list of exact names, deliberately not a prefix match: an agent can register
+// any handle it likes, so `petrus-*` would let a fleet agent call itself
+// "petrus-helper" and inherit approval authority — which is the precise attack
+// this guard was written to stop.
+export function startChatReplyPoller({ apiKey, room, intervalMs = 5000, log, owners = ['petrus'] }) {
   if (!apiKey || !room) {
     process.stderr.write('[iak-mcp] chat-reply poller: missing apiKey or room — disabled\n');
     return null;
   }
+  const ownerSet = new Set(
+    (Array.isArray(owners) && owners.length ? owners : ['petrus'])
+      .map((o) => String(o).replace(/^@/, '').toLowerCase())
+  );
   const emit = log || ((msg) => process.stderr.write(`[iak-mcp] ${msg}\n`));
   const seen = new Set();
   let primed = false;
@@ -1092,8 +1101,13 @@ export function startChatReplyPoller({ apiKey, room, intervalMs = 5000, log }) {
         // which this poller happily executed — any agent could approve any
         // gated command. Agent senders carry a handle ("@ether", "hermes");
         // the owner posts as plain "petrus" (CodeWatch button taps included).
+        // 2026-08-03: this used to compare against the literal "petrus", so a
+        // decision from petrus's own tablet ("@petrus-boox") was dropped in
+        // silence — he tapped Approve on camera and nothing happened. Owner
+        // identities are now configured, because a person is not one handle:
+        // they are a laptop, a tablet and a watch.
         const sender = String(m.from || '').replace(/^@/, '').toLowerCase();
-        if (sender !== 'petrus' && m.isHuman !== true) {
+        if (!ownerSet.has(sender) && m.isHuman !== true) {
           emit(`${text} from ${m.from}: sender is not the owner — ignoring`);
           continue;
         }


### PR DESCRIPTION
petrus tapped Approve from his tablet and nothing happened, on camera, while filming the approval flow.

## The bug

The owner guard compared the sender against the literal string `petrus`. His tablet posts as `@petrus-boox`. Verified in the raw API payload rather than inferred:

| time | `from` | `isHuman` | result |
|---|---|---|---|
| 13:43:46 | `@petrus-boox` | `false` | **dropped**, intent stayed `pending` |
| 14:12:42 | `petrus` | `false` | settled instantly |

Same person, same room, same command, 29 minutes apart.

## The change

`owners` is now a list, read from `mcp.confirmations.owners`, defaulting to `['petrus']` so existing callers behave **exactly** as before.

```
owners unset                      → petrus ✓  @petrus-boox ✗  hermes ✗  petrus-helper ✗
owners ['petrus']                 → petrus ✓  @petrus-boox ✗  hermes ✗  petrus-helper ✗
owners ['petrus','petrus-boox']   → petrus ✓  @petrus-boox ✓  hermes ✗  petrus-helper ✗
```

The `@` prefix is stripped and case normalised on both sides, so `@Petrus-BOOX` in config matches `petrus-boox` on the wire.

## Why an explicit list and not `petrus-*`

A prefix rule is shorter and it is wrong. **Any agent can register any handle**, so `petrus-*` hands approval authority to a fleet agent that calls itself `petrus-helper` — which is exactly the attack this guard was added for, after one auto-replied `/approve <id>` to a confirmation card and the poller executed it. Verified above that `petrus-helper` is rejected.

## What this does not fix

It covers a **typed** `/approve`. The tablet's Approve **button** is a separate path, and while testing this we found the app had stopped posting from that device entirely since 14:03 — so the button is unverified either way, not fixed and not disproven.

## Authorisation

Granting a device handle approval authority grants it to whoever holds that device's API key — a weaker claim than the `isHuman` signal, which marks a signed-in human. petrus asked for this explicitly, with that tradeoff stated and the alternative (merge the visibility fix only, keep approving from the browser) laid out first.

Stacks cleanly beside #54, which makes the rejection *visible*; the two solve different halves and neither depends on the other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
