### PR TITLE
pollers: skip own posts case-insensitively, self handle from config

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,7 +344,7 @@ This integrates with [user-intent-kit](https://github.com/ThinkOffApp/user-inten
 |----------|---------|-------------|
 | `IAK_API_KEY` | (required) | GroupMind API key |
 | `IAK_ROOMS` | `thinkoff-development,feature-admin-planning,lattice-qcd` | Rooms to watch |
-| `IAK_SELF_HANDLES` | `@claudemm,claudemm` | This agent's handles (skip own messages) |
+| `IAK_SELF_HANDLE` | `poller.handle` from config, else `@claudemm` | This agent's handle; its own posts are skipped **case-insensitively** ('@' optional). `IAK_SELF_HANDLES` (comma list) still accepted |
 | `IAK_TARGET_HANDLE` | `@claudemm` | Handle used in ack messages |
 | `IAK_OWNER_HANDLE` | `petrus` | Only auto-ack from this user |
 | `IAK_TMUX_SESSION` | `claude` | tmux session to nudge |

--- a/scripts/claude-gui-poll.sh
+++ b/scripts/claude-gui-poll.sh
@@ -3,7 +3,8 @@
 # Runs in tmux via launchd. Wakes the GUI via osascript on new messages.
 #
 # Required env: IAK_API_KEY
-# Optional env: SELF_HANDLE (default @claudemm), ROOM, POLL_INTERVAL, etc.
+# Optional env: IAK_SELF_HANDLE (or legacy SELF_HANDLE; default @claudemm),
+# ROOM, POLL_INTERVAL, etc.
 #
 # Setup: see examples/claude-gui-launchd.plist and README
 
@@ -11,7 +12,12 @@ set -euo pipefail
 
 API_KEY="${IAK_API_KEY:-}"
 ROOM="${ROOM:-thinkoff-development}"
-SELF_HANDLE="${SELF_HANDLE:-@claudemm}"
+# IAK_SELF_HANDLE wins over legacy SELF_HANDLE. Matching is case-INSENSITIVE:
+# GroupMind returns the handle's registered casing (e.g. @claudeMB) while
+# configs usually hold lowercase; a case-sensitive compare lets every own
+# post back into the wake pipeline.
+SELF_HANDLE="${IAK_SELF_HANDLE:-${SELF_HANDLE:-@claudemm}}"
+SELF_HANDLE_LC="$(printf '%s' "$SELF_HANDLE" | tr '[:upper:]' '[:lower:]')"
 BASE_URL="${BASE_URL:-https://groupmind.one/api/v1}"
 POLL_INTERVAL="${POLL_INTERVAL:-15}"
 FETCH_LIMIT="${FETCH_LIMIT:-20}"
@@ -66,7 +72,8 @@ process_messages() {
     local source="$1" response="$2" count=0
     while IFS=$'\t' read -r msg_id msg_from msg_body; do
         [[ -z "$msg_id" ]] && continue
-        [[ "$msg_from" == "$SELF_HANDLE" || "$msg_from" == "${SELF_HANDLE#@}" ]] && {
+        msg_from_lc="$(printf '%s' "$msg_from" | tr '[:upper:]' '[:lower:]')"
+        [[ "$msg_from_lc" == "$SELF_HANDLE_LC" || "$msg_from_lc" == "${SELF_HANDLE_LC#@}" ]] && {
             grep -qF "$msg_id" "$SEEN_IDS_FILE" || echo "$msg_id" >> "$SEEN_IDS_FILE"; continue; }
         grep -qF "$msg_id" "$SEEN_IDS_FILE" && continue
         echo "$msg_id" >> "$SEEN_IDS_FILE"

--- a/scripts/claudemb-poll.sh
+++ b/scripts/claudemb-poll.sh
@@ -25,8 +25,21 @@ PY
 
 CONFIG_API_KEY="$(read_json_value 'poller.api_key')"
 CONFIG_NUDGE_TEXT="$(read_json_value 'tmux.nudge_text')"
+CONFIG_HANDLE="$(read_json_value 'poller.handle')"
 
 API_KEY="${IAK_API_KEY:-${ANTIGRAVITY_API_KEY:-${CONFIG_API_KEY:-}}}"
+
+# Own-post filter identity: IAK_SELF_HANDLE env override, else poller.handle
+# from config. All comparisons are case-INSENSITIVE and accept a missing '@':
+# GroupMind returns the handle's REGISTERED casing in `from` (e.g. @claudeMB)
+# while configs usually hold lowercase, and that mismatch masked a missing
+# self-filter for months - every post the agent made re-entered its own wake
+# pipeline as a "new message" and burned a wake turn.
+SELF_HANDLE="${IAK_SELF_HANDLE:-${CONFIG_HANDLE:-@claudemb}}"
+SELF_HANDLE_LC="$(printf '%s' "$SELF_HANDLE" | tr '[:upper:]' '[:lower:]')"
+# wake-on-mention.sh skips mentions of IAK_SELF_HANDLE; export the resolved
+# value so that skip also works when only poller.handle was configured.
+export IAK_SELF_HANDLE="$SELF_HANDLE"
 ROOM="${ROOM:-thinkoff-development}"
 BASE_URL="${BASE_URL:-https://antfarm.world/api/v1}"
 POLL_INTERVAL="${POLL_INTERVAL:-15}"
@@ -118,6 +131,7 @@ if [[ ! -s "$LAST_WAKE_FILE" ]]; then
 fi
 
 echo "[claudemb] Polling $ROOM every ${POLL_INTERVAL}s (limit=$FETCH_LIMIT)"
+echo "[claudemb] Self handle: $SELF_HANDLE (own posts skipped, case-insensitive)"
 echo "[claudemb] Seen IDs file: $SEEN_IDS_FILE ($(wc -l < "$SEEN_IDS_FILE" | tr -d ' ') known)"
 echo "[claudemb] Wake target session (exact): $WAKE_SESSION"
 echo "[claudemb] Nudge text: $NUDGE_TEXT (cooldown=${WAKE_COOLDOWN_SEC}s)"
@@ -162,7 +176,7 @@ while true; do
             # asked to kill, 2026-07-02). Marked seen above so we don't
             # reconsider; just don't notify/wake on self-authored messages.
             case "$(printf '%s' "$msg_from" | tr '[:upper:]' '[:lower:]')" in
-                @claudemb|claudemb) continue ;;
+                "$SELF_HANDLE_LC"|"${SELF_HANDLE_LC#@}") continue ;;
             esac
             new_count=$((new_count + 1))
             body_preview="${msg_body:0:120}"
@@ -198,7 +212,7 @@ except Exception:
 
     # --- DM polling ---
     dm_response=$(curl -sS --connect-timeout "$HTTP_CONNECT_TIMEOUT_SEC" --max-time "$HTTP_TIMEOUT_SEC" -H "X-API-Key: $API_KEY" \
-        "$BASE_URL/messages?to=@claudeMB&limit=10" 2>&1) || {
+        "$BASE_URL/messages?to=$SELF_HANDLE&limit=10" 2>&1) || {
         echo "[$(date +%H:%M:%S)] DM fetch error: $dm_response"
     }
 
@@ -214,6 +228,13 @@ except Exception:
             # `--` terminates grep options; required for ids that begin with `-`.
             if ! grep -qF -- "$msg_id" "$DM_SEEN_IDS_FILE"; then
                 echo "$msg_id" >> "$DM_SEEN_IDS_FILE"
+                # Same own-post skip as the room loop: the DM endpoint echoes
+                # the agent's own sent/self DMs back, and each one would
+                # otherwise burn a wake turn. Marked seen above; just don't
+                # notify/wake on it.
+                case "$(printf '%s' "$msg_from" | tr '[:upper:]' '[:lower:]')" in
+                    "$SELF_HANDLE_LC"|"${SELF_HANDLE_LC#@}") continue ;;
+                esac
                 new_count=$((new_count + 1))
                 body_preview="${msg_body:0:120}"
                 echo "[$(date +%H:%M:%S)] DM   ${msg_from}: ${body_preview}"

--- a/scripts/room-poll-check.py
+++ b/scripts/room-poll-check.py
@@ -12,26 +12,54 @@ import sys
 from typing import Iterable, List, Set
 
 BASE_URL = os.getenv("IAK_BASE_URL", "https://antfarm.world/api/v1").rstrip("/")
-API_KEY = os.getenv("IAK_API_KEY") or os.getenv("ANTIGRAVITY_API_KEY", "")
-if not API_KEY:
-    # Fall back to the gitignored machine config so a bare restart of the
-    # poller still authenticates. On 2026-07-06 a restart without IAK_API_KEY
-    # printed NONE (exit 0) every poll for 5 hours - a total silent mute.
-    _cfg_path = os.getenv(
-        "IAK_CONFIG",
-        os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "config", "macbook.json"),
-    )
-    try:
-        with open(_cfg_path) as _f:
-            API_KEY = (json.load(_f).get("poller", {}) or {}).get("api_key", "") or ""
-    except Exception:
-        pass
+# The gitignored machine config is the fallback for both the API key and the
+# agent's own handle, so a bare restart still authenticates and still filters
+# self-posts. On 2026-07-06 a restart without IAK_API_KEY printed NONE
+# (exit 0) every poll for 5 hours - a total silent mute.
+_cfg_path = os.getenv(
+    "IAK_CONFIG",
+    os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "config", "macbook.json"),
+)
+try:
+    with open(_cfg_path) as _f:
+        _POLLER_CFG = json.load(_f).get("poller", {}) or {}
+except Exception:
+    _POLLER_CFG = {}
+
+API_KEY = (
+    os.getenv("IAK_API_KEY")
+    or os.getenv("ANTIGRAVITY_API_KEY", "")
+    or _POLLER_CFG.get("api_key", "")
+    or ""
+)
 ROOMS = [r.strip() for r in os.getenv(
     "IAK_ROOMS", "thinkoff-development,feature-admin-planning,lattice-qcd"
 ).split(",") if r.strip()]
+
+
+def _handle_key(handle: str) -> str:
+    """Normalize a handle for comparison: strip, drop leading '@', lowercase."""
+    return str(handle or "").strip().lstrip("@").lower()
+
+
+# The agent's own handle(s), used to skip its own posts so they never re-enter
+# the wake pipeline. IAK_SELF_HANDLE env override first (IAK_SELF_HANDLES kept
+# as a legacy comma-list alias), then poller.handle from config. Comparison via
+# _handle_key is case-INSENSITIVE: GroupMind returns the handle's REGISTERED
+# casing in `from` (e.g. @claudeMB) while configs usually hold lowercase, and
+# that mismatch masked a broken self-filter - every post the agent made came
+# back as a "new message" and burned a wake turn.
 MY_HANDLES = tuple(
-    h.strip() for h in os.getenv("IAK_SELF_HANDLES", "@claudemm,claudemm").split(",") if h.strip()
+    h.strip()
+    for h in (
+        os.getenv("IAK_SELF_HANDLE")
+        or os.getenv("IAK_SELF_HANDLES")
+        or _POLLER_CFG.get("handle")
+        or "@claudemm"
+    ).split(",")
+    if h.strip()
 )
+_MY_HANDLE_KEYS = {_handle_key(h) for h in MY_HANDLES}
 OWNER_HANDLE = os.getenv("IAK_OWNER_HANDLE", "petrus").lower()
 TARGET_HANDLE = os.getenv("IAK_TARGET_HANDLE", "@claudemm")
 SEEN_FILE = os.getenv("IAK_SEEN_FILE", "/tmp/iak-seen-ids.txt")
@@ -92,9 +120,8 @@ def _passes_listen_filter(handle: str, author_handle: str, body: str) -> bool:
     if LISTEN_MODE == "humans":
         return not _is_bot(handle, author_handle)
     if LISTEN_MODE == "tagged":
-        my_short = {h.lower().lstrip("@") for h in MY_HANDLES}
         mentions = _extract_mentions(body)
-        return any(m in my_short for m in mentions)
+        return any(m in _MY_HANDLE_KEYS for m in mentions)
     if LISTEN_MODE == "owner":
         return OWNER_HANDLE in str(author_handle).lower() or OWNER_HANDLE in str(handle).lower()
     # Unknown mode, default to all
@@ -103,9 +130,8 @@ def _passes_listen_filter(handle: str, author_handle: str, body: str) -> bool:
 
 def _message_targets_me(body: str) -> bool:
     mentions = _extract_mentions(body)
-    my_short = {h.lower().lstrip("@") for h in MY_HANDLES}
     if mentions:
-        return any(m in my_short for m in mentions)
+        return any(m in _MY_HANDLE_KEYS for m in mentions)
     # If no explicit mentions, treat owner imperatives as potentially addressed to current agent.
     return True
 
@@ -181,8 +207,8 @@ def main() -> int:
 
             handle = str(msg.get("from", "?"))
             author_handle = str(msg.get("author", {}).get("handle", handle))
-            # Always skip own messages
-            if author_handle in MY_HANDLES or handle in MY_HANDLES:
+            # Always skip own messages (case-insensitive, '@' optional)
+            if _handle_key(author_handle) in _MY_HANDLE_KEYS or _handle_key(handle) in _MY_HANDLE_KEYS:
                 continue
 
             body = str(msg.get("body", ""))[:1000]

--- a/src/adapters/groupmind.mjs
+++ b/src/adapters/groupmind.mjs
@@ -2,6 +2,7 @@
 
 import { execFileSync } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
+import { resolveSelfHandle, isSelfSender } from '../common/handles.mjs';
 
 /**
  * GroupMind adapter — polls GroupMind rooms for new messages.
@@ -41,9 +42,9 @@ export const groupmindAdapter = {
   },
 
   shouldSkip(msg, config) {
-    const selfHandle = config?.poller?.handle || '@unknown';
+    const selfHandle = resolveSelfHandle({ config });
     const sender = msg.from || msg.sender || '?';
-    return sender === selfHandle || sender === selfHandle.replace('@', '');
+    return isSelfSender(sender, selfHandle);
   },
 
   normalize(msg, config) {

--- a/src/adapters/xfor.mjs
+++ b/src/adapters/xfor.mjs
@@ -2,6 +2,7 @@
 
 import { execFileSync } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
+import { isSelfSender } from '../common/handles.mjs';
 
 /**
  * xfor adapter — polls xfor.bot posts and notifications.
@@ -74,7 +75,7 @@ export const xforAdapter = {
     const selfHandle = config?.xfor?.handle || '';
     if (!selfHandle) return false;
     const sender = msg.author?.handle || msg.from_handle || msg.handle || '';
-    return sender === selfHandle || sender === selfHandle.replace('@', '');
+    return isSelfSender(sender, selfHandle);
   },
 
   normalize(msg) {

--- a/src/common/handles.mjs
+++ b/src/common/handles.mjs
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+ * Self-handle resolution and comparison, shared by every poller that must
+ * skip the agent's own posts.
+ *
+ * The comparison is case-insensitive and ignores a leading '@' on either
+ * side. This is load-bearing: GroupMind returns the handle's REGISTERED
+ * casing in message `from` fields (e.g. '@claudeMB') while configs usually
+ * hold the lowercase form ('@claudemb'). A case-sensitive filter silently
+ * passes every self-post, so each post the agent makes re-enters its own
+ * wake pipeline as a "new message" and burns a wake turn (observed on the
+ * MacBook poller, 2026-08-14).
+ */
+
+/** Normalize a handle for comparison: trim, drop leading '@', lowercase. */
+export function handleKey(handle) {
+  return String(handle ?? '').trim().replace(/^@/, '').toLowerCase();
+}
+
+/**
+ * Resolve the agent's own GroupMind handle.
+ * Order: IAK_SELF_HANDLE env override, explicit value (CLI flag), then the
+ * agent config (poller.handle).
+ */
+export function resolveSelfHandle({ explicit, config } = {}) {
+  return process.env.IAK_SELF_HANDLE || explicit || config?.poller?.handle || '@unknown';
+}
+
+/** True when `sender` is the agent itself (case- and '@'-insensitive). */
+export function isSelfSender(sender, selfHandle) {
+  const key = handleKey(selfHandle);
+  return key !== '' && handleKey(sender) === key;
+}

--- a/src/room-automation.mjs
+++ b/src/room-automation.mjs
@@ -5,6 +5,7 @@ import { readFileSync, writeFileSync, appendFileSync, existsSync } from 'node:fs
 import { randomUUID } from 'node:crypto';
 import { createReceipt, appendReceipt } from './receipt.mjs';
 import { canSend, markSent } from './rate-limiter.mjs';
+import { resolveSelfHandle, isSelfSender } from './common/handles.mjs';
 
 // Ack-only messages are low-value and cause loops. Filter them out from automation posts.
 const ACK_ONLY_PATTERNS = [
@@ -245,7 +246,7 @@ export async function startRoomAutomation({ rooms, apiKey, handle, interval, con
   const seenFile = config?.automation?.seen_file || SEEN_FILE_DEFAULT;
   const receiptPath = config?.receipts?.path || './ide-agent-receipts.jsonl';
   const pollInterval = interval || config?.automation?.interval_sec || 30;
-  const selfHandle = (handle || config?.poller?.handle || '@unknown').replace('@', '');
+  const selfHandle = resolveSelfHandle({ explicit: handle, config });
   const cooldownMs = (config?.automation?.cooldown_sec || 5) * 1000;
 
   console.log(`Room automation started`);
@@ -284,9 +285,9 @@ export async function startRoomAutomation({ rooms, apiKey, handle, interval, con
         if (!m.id || seen.has(m.id)) continue;
         seen.add(m.id);
 
-        // Skip own messages
-        const sender = (m.user?.handle || m.from || m.sender || '').replace('@', '');
-        if (sender === selfHandle) continue;
+        // Skip own messages (case-insensitive; see src/common/handles.mjs)
+        const sender = m.user?.handle || m.from || m.sender || '';
+        if (isSelfSender(sender, selfHandle)) continue;
 
         // Attach room for rule matching
         m.room = room;

--- a/src/room-poller.mjs
+++ b/src/room-poller.mjs
@@ -4,6 +4,7 @@ import { readFileSync, writeFileSync, appendFileSync } from 'node:fs';
 import { randomUUID } from 'node:crypto';
 import { execSync } from 'node:child_process';
 import { nudgeTmux, nudgeCommand } from './utils.mjs';
+import { resolveSelfHandle, isSelfSender } from './common/handles.mjs';
 
 /**
  * Room Poller — polls GroupMind rooms and notifies IDE agent of new messages.
@@ -69,7 +70,7 @@ export async function startRoomPoller({ rooms, apiKey, handle, interval, config,
   const nudgeMode = config?.poller?.nudge_mode || 'tmux';
   const nudgeCommandText = config?.poller?.nudge_command || '';
   const pollInterval = interval || config?.poller?.interval_sec || 30;
-  const selfHandle = handle || config?.poller?.handle || '@unknown';
+  const selfHandle = resolveSelfHandle({ explicit: handle, config });
 
   console.log('Room poller started');
   console.log(`  rooms: ${rooms.join(', ')}`);
@@ -123,7 +124,7 @@ export async function startRoomPoller({ rooms, apiKey, handle, interval, config,
         seen.add(mid);
 
         const sender = m.from || m.sender || '?';
-        if (sender === selfHandle || sender === selfHandle.replace('@', '')) continue;
+        if (isSelfSender(sender, selfHandle)) continue;
 
         const body = (m.body || '').slice(0, 500);
         const ts = m.created_at || new Date().toISOString();

--- a/src/team-relay/room-poller.mjs
+++ b/src/team-relay/room-poller.mjs
@@ -7,6 +7,7 @@ import { readFileSync, writeFileSync, appendFileSync, existsSync, unlinkSync } f
 import { randomUUID } from 'node:crypto';
 import { nudgeCommand } from '../utils.mjs';
 import { shouldSuppressNudge } from '../intent.mjs';
+import { resolveSelfHandle } from '../common/handles.mjs';
 
 /**
  * Room Poller — polls GroupMind rooms and notifies IDE agent of new messages.
@@ -45,7 +46,11 @@ const DM_SEEN_FILE_DEFAULT = '/tmp/iak-dm-seen-ids.txt';
 
 function normalizeHandle(handle) {
   if (typeof handle !== 'string') return '';
-  const trimmed = handle.trim();
+  // Lowercased for comparison: GroupMind returns the handle's REGISTERED
+  // casing in `from` fields (e.g. '@claudeMB') while configs usually hold
+  // '@claudemb'. Handles are case-insensitive identities; a case-sensitive
+  // compare let every self-post back into the wake pipeline.
+  const trimmed = handle.trim().toLowerCase();
   if (!trimmed) return '';
   return trimmed.startsWith('@') ? trimmed : `@${trimmed}`;
 }
@@ -154,7 +159,7 @@ export async function startRoomPoller({ rooms, apiKey, handle, interval, config,
   const nudgeMode = config?.poller?.nudge_mode || 'tmux';
   const nudgeCommandText = config?.poller?.nudge_command || '';
   const pollInterval = parsePositiveInt(interval || config?.poller?.interval_sec, 30);
-  const selfHandle = normalizeHandle(handle || config?.poller?.handle || '@unknown');
+  const selfHandle = normalizeHandle(resolveSelfHandle({ explicit: handle, config }));
   // The human owner's handle. Messages from the owner ALWAYS nudge, even in
   // emergency-only mode — a message from the user is itself the priority signal;
   // emergency-only is meant to mute agent/fleet chatter, not the user's own words.

--- a/test/handles.test.mjs
+++ b/test/handles.test.mjs
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { handleKey, isSelfSender, resolveSelfHandle } from '../src/common/handles.mjs';
+import { groupmindAdapter } from '../src/adapters/groupmind.mjs';
+import { xforAdapter } from '../src/adapters/xfor.mjs';
+
+describe('handles', () => {
+  it('handleKey normalizes case, whitespace, and leading @', () => {
+    assert.equal(handleKey('@claudeMB'), 'claudemb');
+    assert.equal(handleKey(' claudeMB '), 'claudemb');
+    assert.equal(handleKey('@claudemb'), 'claudemb');
+    assert.equal(handleKey(''), '');
+    assert.equal(handleKey(undefined), '');
+  });
+
+  it('matches the registered casing against a lowercase config handle', () => {
+    // The masked-bug case: registered handle is @claudeMB (capital MB),
+    // config holds @claudemb, and GroupMind returns the registered casing
+    // in message `from` fields.
+    assert.equal(isSelfSender('@claudeMB', '@claudemb'), true);
+    assert.equal(isSelfSender('claudeMB', '@claudemb'), true);
+    assert.equal(isSelfSender('@claudemb', '@claudeMB'), true);
+  });
+
+  it('does not match other agents', () => {
+    assert.equal(isSelfSender('@claudemm', '@claudemb'), false);
+    assert.equal(isSelfSender('@petrus', '@claudemb'), false);
+  });
+
+  it('never matches when the self handle is empty', () => {
+    assert.equal(isSelfSender('@anyone', ''), false);
+    assert.equal(isSelfSender('', ''), false);
+  });
+
+  it('resolveSelfHandle prefers the IAK_SELF_HANDLE env override', () => {
+    process.env.IAK_SELF_HANDLE = '@override';
+    try {
+      assert.equal(
+        resolveSelfHandle({ explicit: '@cli', config: { poller: { handle: '@cfg' } } }),
+        '@override'
+      );
+    } finally {
+      delete process.env.IAK_SELF_HANDLE;
+    }
+  });
+
+  it('resolveSelfHandle falls back explicit → config → @unknown', () => {
+    delete process.env.IAK_SELF_HANDLE;
+    assert.equal(
+      resolveSelfHandle({ explicit: '@cli', config: { poller: { handle: '@cfg' } } }),
+      '@cli'
+    );
+    assert.equal(resolveSelfHandle({ config: { poller: { handle: '@cfg' } } }), '@cfg');
+    assert.equal(resolveSelfHandle({}), '@unknown');
+  });
+});
+
+describe('adapter self-skip', () => {
+  it('groupmind shouldSkip is case-insensitive', () => {
+    const config = { poller: { handle: '@claudemb' } };
+    assert.equal(groupmindAdapter.shouldSkip({ from: '@claudeMB' }, config), true);
+    assert.equal(groupmindAdapter.shouldSkip({ from: 'claudeMB' }, config), true);
+    assert.equal(groupmindAdapter.shouldSkip({ from: '@petrus' }, config), false);
+  });
+
+  it('groupmind shouldSkip honors the IAK_SELF_HANDLE env override', () => {
+    process.env.IAK_SELF_HANDLE = '@claudeMB';
+    try {
+      assert.equal(groupmindAdapter.shouldSkip({ from: '@claudemb' }, {}), true);
+      assert.equal(groupmindAdapter.shouldSkip({ from: '@claudemm' }, {}), false);
+    } finally {
+      delete process.env.IAK_SELF_HANDLE;
+    }
+  });
+
+  it('xfor shouldSkip is case-insensitive', () => {
+    const config = { xfor: { handle: '@ClaudeMB' } };
+    assert.equal(xforAdapter.shouldSkip({ author: { handle: '@claudemb' } }, config), true);
+    assert.equal(xforAdapter.shouldSkip({ author: { handle: '@other' } }, config), false);
+    // No configured handle → never skip
+    assert.equal(xforAdapter.shouldSkip({ author: { handle: '@claudemb' } }, {}), false);
+  });
+});


### PR DESCRIPTION
## Problem

Every poller that feeds an agent's wake pipeline must drop the agent's OWN posts, or each post the agent makes re-enters the new-messages file as a "new message" and burns a wake turn (an echo loop of self-wakes).

On 2026-08-14 the MacBook room/DM poller was found shipping with **no self-filter at all in its DM path**, a hardcoded one in its room path, and its stop-hook text even claimed "your own posts are filtered out by the poller", which was false. Worse, the filters that did exist across the kit compared handles **case-sensitively**, which masked the bug: GroupMind returns the handle's REGISTERED casing in message `from` fields (e.g. `@claudeMB`) while configs usually hold lowercase (`@claudemb`), so a `===` filter never matched. Live proof: posting via the MCP server with config handle `@claudemb` returns `"from": "@claudeMB"`.

## Fix (construction, not instances)

- **New `src/common/handles.mjs`** shared by all Node pollers:
  - `handleKey()` — trim, drop leading `@`, lowercase
  - `resolveSelfHandle()` — `IAK_SELF_HANDLE` env override → explicit CLI value → `poller.handle` from the agent's config
  - `isSelfSender()` — case- and `@`-insensitive comparison, never matches an empty handle
- **`src/room-poller.mjs`, `src/adapters/groupmind.mjs`, `src/adapters/xfor.mjs`, `src/room-automation.mjs`** — replace hand-rolled case-sensitive compares with the shared helper.
- **`src/team-relay/room-poller.mjs`** — `normalizeHandle()` now lowercases, making the room self-skip, DM self-skip, and owner detection case-insensitive; self handle resolves through `resolveSelfHandle()`.
- **`scripts/claudemb-poll.sh`** — self handle sourced from `poller.handle` in config (`IAK_SELF_HANDLE` env wins) instead of hardcoded; the **DM loop gains the missing self-skip**; the DM fetch URL uses the resolved handle (the DM endpoint's `to=` filter is case-insensitive, verified against the live API); the resolved handle is exported as `IAK_SELF_HANDLE` so `wake-on-mention.sh`'s self-mention skip actually engages (it previously defaulted to empty).
- **`scripts/claude-gui-poll.sh`** — comparison lowercased; `IAK_SELF_HANDLE` supported, legacy `SELF_HANDLE` kept.
- **`scripts/room-poll-check.py`** — own-handle membership normalized case-insensitively; handle sourced from `IAK_SELF_HANDLE` (legacy `IAK_SELF_HANDLES` comma list kept) or `poller.handle` in the machine config, so new-user defaults come from config rather than a hardcoded handle.
- **README** — env table updated.

## Tests

- New `test/handles.test.mjs` (9 tests) covering the exact masked-bug case (`@claudeMB` vs `@claudemb`), env-override precedence, empty-handle safety, and adapter `shouldSkip` behavior.
- Full suite: **220/220 pass**.
- `bash -n` / `py_compile` clean; `room-poll-check.py` exercised with `IAK_SELF_HANDLE` override and with `config/grok.example.json` (`poller.handle` → `@grok` picked up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)