### PR TITLE
feat(uik): publish host vitals (load, temp) as an object

### DIFF
--- a/packages/user-intent-kit/bin/uik-daemon.js
+++ b/packages/user-intent-kit/bin/uik-daemon.js
@@ -48,7 +48,7 @@ if (userId.toLowerCase() === agentHandle.replace(/^@/, '').toLowerCase()) {
 }
 
 const client = new IntentClient({ baseUrl, apiKey, userId, deviceId });
-const iak = new IAKAdapter(client, { agentHandle });
+const iak = new IAKAdapter(client, { agentHandle, machine: deviceId });
 const desktop = new DesktopAdapter(client, { pollIntervalMs });
 
 desktop.start();

--- a/packages/user-intent-kit/package.json
+++ b/packages/user-intent-kit/package.json
@@ -16,7 +16,7 @@
     "./adapters/browser": "./src/adapters/browser.js"
   },
   "scripts": {
-    "test": "node --test test/client.test.js",
+    "test": "node --test test/*.test.js",
     "daemon": "node bin/uik-daemon.js"
   },
   "keywords": [

--- a/packages/user-intent-kit/src/adapters/iak.js
+++ b/packages/user-intent-kit/src/adapters/iak.js
@@ -1,34 +1,44 @@
 // SPDX-License-Identifier: AGPL-3.0
 
+import { collectHostTelemetry } from '../host-telemetry.js';
+
 /**
  * IAK Adapter - integrates user-intent-kit with IDE Agent Kit.
  *
- * Publishes: active agent, current task, tmux session status.
+ * Publishes: active agent, current task, tmux session status, host vitals.
  * Subscribes: user availability (suppress nudges during meetings).
  */
 export class IAKAdapter {
   #client;
   #agentHandle;
+  #machine;
 
   /**
    * @param {import('../client.js').IntentClient} client
    * @param {object} opts
    * @param {string} opts.agentHandle - e.g. "@claudemm"
+   * @param {string} [opts.machine] - stable device name published in host vitals
    */
-  constructor(client, { agentHandle }) {
+  constructor(client, { agentHandle, machine }) {
     this.#client = client;
     this.#agentHandle = agentHandle;
+    this.#machine = machine;
   }
 
   /**
    * Publish current agent status to intent state.
    * Call this on each room poll cycle.
+   *
+   * `host` carries the machine's vitals as an object. It was previously a bare
+   * string on some publishers, which gave the dashboard nowhere to put a
+   * temperature or a load figure.
    */
   async publishStatus({ status = 'active', currentTask = null }) {
     const name = this.#agentHandle.replace(/^@/, '');
     await this.#client.patchAgent(name, {
       status,
       last_task: currentTask,
+      host: collectHostTelemetry({ machine: this.#machine }),
     });
   }
 

--- a/packages/user-intent-kit/src/adapters/iak.js
+++ b/packages/user-intent-kit/src/adapters/iak.js
@@ -17,12 +17,16 @@ export class IAKAdapter {
    * @param {import('../client.js').IntentClient} client
    * @param {object} opts
    * @param {string} opts.agentHandle - e.g. "@claudemm"
-   * @param {string} [opts.machine] - stable device name published in host vitals
+   * @param {string} [opts.machine] - stable device name published in host
+   *   vitals. Defaults to the client's configured deviceId, so callers that
+   *   predate host vitals keep naming their machine: `host` replaces the
+   *   stored value wholesale, so publishing it without a name would overwrite
+   *   a known hostname with anonymous load readings.
    */
   constructor(client, { agentHandle, machine }) {
     this.#client = client;
     this.#agentHandle = agentHandle;
-    this.#machine = machine;
+    this.#machine = machine ?? client?.deviceId ?? undefined;
   }
 
   /**

--- a/packages/user-intent-kit/src/client.js
+++ b/packages/user-intent-kit/src/client.js
@@ -32,6 +32,11 @@ export class IntentClient {
     this.#heartbeatTimer = null;
   }
 
+  /** Device slot this client writes to, or null for a read-only client. */
+  get deviceId() {
+    return this.#deviceId;
+  }
+
   // --- Profile (static layer) ---
 
   async getProfile() {

--- a/packages/user-intent-kit/src/host-telemetry.js
+++ b/packages/user-intent-kit/src/host-telemetry.js
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: AGPL-3.0
+
+/**
+ * Host vitals for the UIK agent record (CPU load, temperature, power).
+ *
+ * Contract: every field is OPTIONAL and a value we cannot read is OMITTED,
+ * never zeroed. A zero renders in the dashboard as a real reading — an idle
+ * box and an unreadable sensor must not look the same.
+ *
+ * Nothing here throws: telemetry is decoration on the heartbeat, so a failed
+ * sensor read must never take the agent offline.
+ */
+
+import { readFileSync, readdirSync } from 'node:fs';
+import { cpus, loadavg, platform } from 'node:os';
+
+/** Plausible CPU die temperatures. Outside this, assume the sensor lied. */
+const TEMP_MIN_C = 1;
+const TEMP_MAX_C = 150;
+
+/**
+ * CPU load, normalised so devices of different sizes are comparable.
+ *
+ * Raw loadavg is meaningless across a fleet: 1.8 is ~18% of a 10-core M4 but
+ * ~45% of a 4-core Pi. The dashboard compares boxes side by side, so it needs
+ * the percentage, and we publish the raw figure alongside it for anyone who
+ * wants the familiar number.
+ *
+ * @returns {{load_1m?: number, load_pct?: number, cpu_count?: number}}
+ */
+function readLoad() {
+  const count = cpus()?.length;
+  const [oneMinute] = loadavg();
+
+  // Windows has no load average; Node reports [0, 0, 0] there. That is an
+  // absent sensor, not an idle machine, so report nothing at all.
+  if (platform() === 'win32' || !Number.isFinite(oneMinute)) return {};
+
+  const out = { load_1m: Math.round(oneMinute * 100) / 100 };
+  if (Number.isFinite(count) && count > 0) {
+    out.cpu_count = count;
+    out.load_pct = Math.round((oneMinute / count) * 100);
+  }
+  return out;
+}
+
+/**
+ * CPU temperature from the Linux thermal zones (Raspberry Pi and friends).
+ *
+ * sysfs reports millidegrees. A board exposes several zones and they do not
+ * agree; the hottest plausible one is what "the CPU temperature" means to
+ * someone reading a dashboard, so that is what we publish.
+ *
+ * @returns {number|undefined} degrees Celsius
+ */
+function readLinuxTempC() {
+  let hottest;
+  let zones;
+  try {
+    zones = readdirSync('/sys/class/thermal').filter((z) => z.startsWith('thermal_zone'));
+  } catch {
+    return undefined;
+  }
+
+  for (const zone of zones) {
+    try {
+      const milli = Number(readFileSync(`/sys/class/thermal/${zone}/temp`, 'utf8').trim());
+      const celsius = milli / 1000;
+      if (celsius >= TEMP_MIN_C && celsius <= TEMP_MAX_C) {
+        if (hottest === undefined || celsius > hottest) hottest = celsius;
+      }
+    } catch {
+      // Unreadable zone: skip it, keep whatever the other zones gave us.
+    }
+  }
+  return hottest === undefined ? undefined : Math.round(hottest * 10) / 10;
+}
+
+/**
+ * Collect what this host can actually report.
+ *
+ * Temperature and power on macOS live behind `powermetrics`, which requires
+ * root. We deliberately do not shell out to sudo from a long-running daemon,
+ * so a Mac publishes load only until a privileged helper feeds it a reading.
+ * That is why a Mac shows load but no temperature: the sensor is gated, not
+ * missing.
+ *
+ * @param {object} [opts]
+ * @param {string} [opts.machine] - stable device name (e.g. "mac-mini")
+ * @returns {object} only the fields that were readable
+ */
+export function collectHostTelemetry({ machine } = {}) {
+  const host = {};
+  if (machine) host.machine = machine;
+
+  try {
+    Object.assign(host, readLoad());
+  } catch {
+    // Load is best-effort like everything else here.
+  }
+
+  if (platform() === 'linux') {
+    try {
+      const tempC = readLinuxTempC();
+      if (tempC !== undefined) host.temp_c = tempC;
+    } catch {
+      // No thermal zones exposed; publish without a temperature.
+    }
+  }
+
+  return host;
+}

--- a/packages/user-intent-kit/src/host-telemetry.js
+++ b/packages/user-intent-kit/src/host-telemetry.js
@@ -9,6 +9,11 @@
  *
  * Nothing here throws: telemetry is decoration on the heartbeat, so a failed
  * sensor read must never take the agent offline.
+ *
+ * The platform reads are injectable (`sources`) so the contract can be tested
+ * on any machine. Without that, a suite running on macOS never exercises the
+ * Linux thermal path at all, and "the tests pass" would mean only that they
+ * passed on whichever box happened to run them.
  */
 
 import { readFileSync, readdirSync } from 'node:fs';
@@ -17,6 +22,17 @@ import { cpus, loadavg, platform } from 'node:os';
 /** Plausible CPU die temperatures. Outside this, assume the sensor lied. */
 const TEMP_MIN_C = 1;
 const TEMP_MAX_C = 150;
+
+const THERMAL_ROOT = '/sys/class/thermal';
+
+/** Real sensor reads. Swapped out wholesale in tests. */
+export const defaultSources = {
+  platform: () => platform(),
+  loadavg: () => loadavg(),
+  cpuCount: () => cpus()?.length,
+  listThermalZones: () => readdirSync(THERMAL_ROOT).filter((z) => z.startsWith('thermal_zone')),
+  readThermalZone: (zone) => readFileSync(`${THERMAL_ROOT}/${zone}/temp`, 'utf8'),
+};
 
 /**
  * CPU load, normalised so devices of different sizes are comparable.
@@ -28,15 +44,17 @@ const TEMP_MAX_C = 150;
  *
  * @returns {{load_1m?: number, load_pct?: number, cpu_count?: number}}
  */
-function readLoad() {
-  const count = cpus()?.length;
-  const [oneMinute] = loadavg();
-
+function readLoad(sources) {
   // Windows has no load average; Node reports [0, 0, 0] there. That is an
   // absent sensor, not an idle machine, so report nothing at all.
-  if (platform() === 'win32' || !Number.isFinite(oneMinute)) return {};
+  if (sources.platform() === 'win32') return {};
+
+  const [oneMinute] = sources.loadavg() || [];
+  if (!Number.isFinite(oneMinute)) return {};
 
   const out = { load_1m: Math.round(oneMinute * 100) / 100 };
+
+  const count = sources.cpuCount();
   if (Number.isFinite(count) && count > 0) {
     out.cpu_count = count;
     out.load_pct = Math.round((oneMinute / count) * 100);
@@ -53,19 +71,18 @@ function readLoad() {
  *
  * @returns {number|undefined} degrees Celsius
  */
-function readLinuxTempC() {
-  let hottest;
+function readLinuxTempC(sources) {
   let zones;
   try {
-    zones = readdirSync('/sys/class/thermal').filter((z) => z.startsWith('thermal_zone'));
+    zones = sources.listThermalZones();
   } catch {
     return undefined;
   }
 
-  for (const zone of zones) {
+  let hottest;
+  for (const zone of zones || []) {
     try {
-      const milli = Number(readFileSync(`/sys/class/thermal/${zone}/temp`, 'utf8').trim());
-      const celsius = milli / 1000;
+      const celsius = Number(String(sources.readThermalZone(zone)).trim()) / 1000;
       if (celsius >= TEMP_MIN_C && celsius <= TEMP_MAX_C) {
         if (hottest === undefined || celsius > hottest) hottest = celsius;
       }
@@ -87,25 +104,26 @@ function readLinuxTempC() {
  *
  * @param {object} [opts]
  * @param {string} [opts.machine] - stable device name (e.g. "mac-mini")
+ * @param {object} [opts.sources] - injectable sensor reads, for tests
  * @returns {object} only the fields that were readable
  */
-export function collectHostTelemetry({ machine } = {}) {
+export function collectHostTelemetry({ machine, sources = defaultSources } = {}) {
   const host = {};
   if (machine) host.machine = machine;
 
   try {
-    Object.assign(host, readLoad());
+    Object.assign(host, readLoad(sources));
   } catch {
     // Load is best-effort like everything else here.
   }
 
-  if (platform() === 'linux') {
-    try {
-      const tempC = readLinuxTempC();
+  try {
+    if (sources.platform() === 'linux') {
+      const tempC = readLinuxTempC(sources);
       if (tempC !== undefined) host.temp_c = tempC;
-    } catch {
-      // No thermal zones exposed; publish without a temperature.
     }
+  } catch {
+    // No thermal zones exposed; publish without a temperature.
   }
 
   return host;

--- a/packages/user-intent-kit/src/index.js
+++ b/packages/user-intent-kit/src/index.js
@@ -5,3 +5,4 @@ export { IAKAdapter } from './adapters/iak.js';
 export { OpenClawAdapter } from './adapters/openclaw.js';
 export { DesktopAdapter } from './adapters/desktop.js';
 export { BrowserAdapter } from './adapters/browser.js';
+export { collectHostTelemetry } from './host-telemetry.js';

--- a/packages/user-intent-kit/test/host-telemetry.test.js
+++ b/packages/user-intent-kit/test/host-telemetry.test.js
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: AGPL-3.0
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { platform } from 'node:os';
+
+import { collectHostTelemetry } from '../src/host-telemetry.js';
+
+test('never publishes a placeholder for a sensor it could not read', () => {
+  const host = collectHostTelemetry({ machine: 'test-box' });
+
+  // The whole contract. A zero here renders in the dashboard as a real
+  // reading, so an unreadable sensor must leave the key absent entirely.
+  for (const [key, value] of Object.entries(host)) {
+    assert.notEqual(value, null, `${key} published as null`);
+    assert.notEqual(value, undefined, `${key} published as undefined`);
+  }
+  assert.ok(!('temp_c' in host) || typeof host.temp_c === 'number');
+  assert.ok(!('watts_w' in host) || typeof host.watts_w === 'number');
+});
+
+test('passes the machine name through', () => {
+  assert.equal(collectHostTelemetry({ machine: 'mac-mini' }).machine, 'mac-mini');
+});
+
+test('omits the machine name rather than inventing one', () => {
+  assert.ok(!('machine' in collectHostTelemetry()));
+});
+
+test('normalises load against core count so devices are comparable', () => {
+  const host = collectHostTelemetry();
+  if (!('load_pct' in host)) return; // platform without load average
+
+  assert.ok(Number.isFinite(host.cpu_count) && host.cpu_count > 0);
+  assert.ok(Number.isFinite(host.load_1m) && host.load_1m >= 0);
+  assert.ok(host.load_pct >= 0);
+
+  // 1.8 on a 10-core box is ~18%, on a 4-core Pi ~45%: the percentage is the
+  // only figure that means the same thing on every device in the fleet.
+  const expected = Math.round((host.load_1m / host.cpu_count) * 100);
+  assert.equal(host.load_pct, expected);
+});
+
+test('reports a plausible temperature or none at all', () => {
+  const host = collectHostTelemetry();
+  if ('temp_c' in host) {
+    assert.ok(host.temp_c > 0 && host.temp_c <= 150, `implausible temp ${host.temp_c}`);
+  }
+});
+
+test('macOS omits temperature rather than reporting zero', { skip: platform() !== 'darwin' }, () => {
+  // powermetrics needs root and the daemon deliberately does not use sudo, so
+  // a Mac has no temperature to publish. It must be absent, not 0.
+  const host = collectHostTelemetry({ machine: 'mac-mini' });
+  assert.ok(!('temp_c' in host), 'macOS published a temperature it cannot read');
+  assert.ok('load_1m' in host, 'macOS should still publish load');
+});
+
+test('does not throw when the host exposes nothing useful', () => {
+  assert.doesNotThrow(() => collectHostTelemetry({}));
+});

--- a/packages/user-intent-kit/test/host-telemetry.test.js
+++ b/packages/user-intent-kit/test/host-telemetry.test.js
@@ -2,60 +2,154 @@
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { platform } from 'node:os';
 
 import { collectHostTelemetry } from '../src/host-telemetry.js';
 
-test('never publishes a placeholder for a sensor it could not read', () => {
-  const host = collectHostTelemetry({ machine: 'test-box' });
+/**
+ * Fake sensors. The real ones only report whatever the machine running the
+ * suite happens to expose, so on a Mac the Linux thermal path would never run
+ * and "tests pass" would say nothing about the Pi.
+ */
+function sources({ platform = 'linux', load = [1.8, 1.7, 1.6], cpuCount = 4, zones = {} } = {}) {
+  return {
+    platform: () => platform,
+    loadavg: () => load,
+    cpuCount: () => cpuCount,
+    listThermalZones: () => Object.keys(zones),
+    readThermalZone: (zone) => {
+      const value = zones[zone];
+      if (value instanceof Error) throw value;
+      return value;
+    },
+  };
+}
 
-  // The whole contract. A zero here renders in the dashboard as a real
-  // reading, so an unreadable sensor must leave the key absent entirely.
+// --- the omit-not-zero contract, the whole point of this module ---
+
+test('a sensor reading 0 is omitted, not published as a temperature', () => {
+  const host = collectHostTelemetry({ sources: sources({ zones: { thermal_zone0: '0' } }) });
+  assert.ok(!('temp_c' in host), 'published a 0 C reading as if it were real');
+});
+
+test('an implausible sensor reading is omitted rather than published', () => {
+  for (const bogus of ['999000', '-40000', 'not-a-number', '']) {
+    const host = collectHostTelemetry({ sources: sources({ zones: { thermal_zone0: bogus } }) });
+    assert.ok(!('temp_c' in host), `published implausible reading ${bogus}`);
+  }
+});
+
+test('no field is ever published as null or undefined', () => {
+  const host = collectHostTelemetry({ machine: 'pi', sources: sources({ zones: { thermal_zone0: '43500' } }) });
   for (const [key, value] of Object.entries(host)) {
     assert.notEqual(value, null, `${key} published as null`);
     assert.notEqual(value, undefined, `${key} published as undefined`);
   }
-  assert.ok(!('temp_c' in host) || typeof host.temp_c === 'number');
-  assert.ok(!('watts_w' in host) || typeof host.watts_w === 'number');
 });
 
+// --- Linux thermal zones (the Pi) ---
+
+test('publishes CPU temperature from the Linux thermal zones', () => {
+  const host = collectHostTelemetry({ sources: sources({ zones: { thermal_zone0: '43500' } }) });
+  assert.equal(host.temp_c, 43.5);
+});
+
+test('reports the hottest plausible zone, ignoring implausible ones', () => {
+  const host = collectHostTelemetry({
+    sources: sources({
+      zones: { thermal_zone0: '43500', thermal_zone1: '51200', thermal_zone2: '999000' },
+    }),
+  });
+  assert.equal(host.temp_c, 51.2);
+});
+
+test('an unreadable zone does not lose the readable ones', () => {
+  const host = collectHostTelemetry({
+    sources: sources({
+      zones: { thermal_zone0: new Error('EACCES'), thermal_zone1: '47000' },
+    }),
+  });
+  assert.equal(host.temp_c, 47);
+});
+
+test('a host with no thermal zones at all publishes no temperature', () => {
+  const bare = sources();
+  bare.listThermalZones = () => {
+    throw new Error('ENOENT');
+  };
+  const host = collectHostTelemetry({ sources: bare });
+  assert.ok(!('temp_c' in host));
+  assert.ok('load_1m' in host, 'a missing thermal sensor must not suppress load');
+});
+
+// --- platform gates ---
+
+test('macOS publishes load but never a temperature', () => {
+  // powermetrics needs root and the daemon deliberately does not use sudo.
+  const host = collectHostTelemetry({
+    machine: 'mac-mini',
+    sources: sources({ platform: 'darwin', zones: { thermal_zone0: '43500' } }),
+  });
+  assert.ok(!('temp_c' in host), 'macOS published a temperature it cannot read');
+  assert.equal(host.load_1m, 1.8);
+});
+
+test('Windows reports no load rather than a fake zero', () => {
+  const host = collectHostTelemetry({ sources: sources({ platform: 'win32', load: [0, 0, 0] }) });
+  assert.ok(!('load_1m' in host), 'published Node\'s [0,0,0] placeholder as real load');
+  assert.ok(!('load_pct' in host));
+});
+
+// --- load normalisation ---
+
+test('normalises load against core count so devices are comparable', () => {
+  // The same 1.8 load means something different on each box.
+  const pi = collectHostTelemetry({ sources: sources({ cpuCount: 4 }) });
+  const mini = collectHostTelemetry({ sources: sources({ cpuCount: 10 }) });
+
+  assert.equal(pi.load_pct, 45);
+  assert.equal(mini.load_pct, 18);
+  assert.equal(pi.load_1m, mini.load_1m, 'raw load is identical; only the percentage separates them');
+});
+
+test('publishes raw load even when core count is unavailable', () => {
+  const noCpus = sources();
+  noCpus.cpuCount = () => undefined;
+  const host = collectHostTelemetry({ sources: noCpus });
+  assert.equal(host.load_1m, 1.8);
+  assert.ok(!('load_pct' in host), 'cannot normalise without a core count');
+  assert.ok(!('cpu_count' in host));
+});
+
+// --- misc contract ---
+
 test('passes the machine name through', () => {
-  assert.equal(collectHostTelemetry({ machine: 'mac-mini' }).machine, 'mac-mini');
+  assert.equal(collectHostTelemetry({ machine: 'mac-mini', sources: sources() }).machine, 'mac-mini');
 });
 
 test('omits the machine name rather than inventing one', () => {
-  assert.ok(!('machine' in collectHostTelemetry()));
+  assert.ok(!('machine' in collectHostTelemetry({ sources: sources() })));
 });
 
-test('normalises load against core count so devices are comparable', () => {
-  const host = collectHostTelemetry();
-  if (!('load_pct' in host)) return; // platform without load average
-
-  assert.ok(Number.isFinite(host.cpu_count) && host.cpu_count > 0);
-  assert.ok(Number.isFinite(host.load_1m) && host.load_1m >= 0);
-  assert.ok(host.load_pct >= 0);
-
-  // 1.8 on a 10-core box is ~18%, on a 4-core Pi ~45%: the percentage is the
-  // only figure that means the same thing on every device in the fleet.
-  const expected = Math.round((host.load_1m / host.cpu_count) * 100);
-  assert.equal(host.load_pct, expected);
+test('never throws, whatever the sensors do', () => {
+  const hostile = {
+    platform: () => 'linux',
+    loadavg: () => {
+      throw new Error('boom');
+    },
+    cpuCount: () => {
+      throw new Error('boom');
+    },
+    listThermalZones: () => {
+      throw new Error('boom');
+    },
+    readThermalZone: () => {
+      throw new Error('boom');
+    },
+  };
+  assert.doesNotThrow(() => collectHostTelemetry({ machine: 'x', sources: hostile }));
+  assert.deepEqual(collectHostTelemetry({ machine: 'x', sources: hostile }), { machine: 'x' });
 });
 
-test('reports a plausible temperature or none at all', () => {
-  const host = collectHostTelemetry();
-  if ('temp_c' in host) {
-    assert.ok(host.temp_c > 0 && host.temp_c <= 150, `implausible temp ${host.temp_c}`);
-  }
-});
-
-test('macOS omits temperature rather than reporting zero', { skip: platform() !== 'darwin' }, () => {
-  // powermetrics needs root and the daemon deliberately does not use sudo, so
-  // a Mac has no temperature to publish. It must be absent, not 0.
-  const host = collectHostTelemetry({ machine: 'mac-mini' });
-  assert.ok(!('temp_c' in host), 'macOS published a temperature it cannot read');
-  assert.ok('load_1m' in host, 'macOS should still publish load');
-});
-
-test('does not throw when the host exposes nothing useful', () => {
-  assert.doesNotThrow(() => collectHostTelemetry({}));
+test('works against the real machine without arguments', () => {
+  assert.doesNotThrow(() => collectHostTelemetry());
 });

--- a/packages/user-intent-kit/test/iak-adapter.test.js
+++ b/packages/user-intent-kit/test/iak-adapter.test.js
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: AGPL-3.0
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { IAKAdapter } from '../src/adapters/iak.js';
+
+/** Captures what the adapter would PATCH, without touching the network. */
+function fakeClient({ deviceId = 'mac-mini' } = {}) {
+  const patches = [];
+  return {
+    deviceId,
+    patches,
+    async patchAgent(name, fields) {
+      patches.push({ name, fields });
+    },
+  };
+}
+
+test('a caller that omits machine still names its host', async () => {
+  // src/intent.mjs constructs the adapter with only agentHandle. `host`
+  // replaces the stored value wholesale, so publishing it without a machine
+  // name would overwrite a known hostname with anonymous load readings.
+  const client = fakeClient({ deviceId: 'mac-mini' });
+  await new IAKAdapter(client, { agentHandle: '@claudemm' }).publishStatus({});
+
+  const { host } = client.patches[0].fields;
+  assert.equal(host.machine, 'mac-mini');
+});
+
+test('an explicit machine name wins over the client default', async () => {
+  const client = fakeClient({ deviceId: 'from-client' });
+  await new IAKAdapter(client, { agentHandle: '@a', machine: 'explicit' }).publishStatus({});
+
+  assert.equal(client.patches[0].fields.host.machine, 'explicit');
+});
+
+test('a read-only client omits the machine rather than publishing null', async () => {
+  const client = fakeClient({ deviceId: null });
+  await new IAKAdapter(client, { agentHandle: '@a' }).publishStatus({});
+
+  const { host } = client.patches[0].fields;
+  assert.ok(!('machine' in host), 'published a machine key with no name behind it');
+});
+
+test('publishes host as an object, never a bare string', async () => {
+  const client = fakeClient();
+  await new IAKAdapter(client, { agentHandle: '@a' }).publishStatus({});
+
+  const { host } = client.patches[0].fields;
+  assert.equal(typeof host, 'object');
+  assert.notEqual(host, null);
+});
+
+test('still publishes status and last_task alongside the vitals', async () => {
+  const client = fakeClient();
+  await new IAKAdapter(client, { agentHandle: '@claudemm' }).publishStatus({
+    status: 'active',
+    currentTask: 'reviewing',
+  });
+
+  const { name, fields } = client.patches[0];
+  assert.equal(name, 'claudemm');
+  assert.equal(fields.status, 'active');
+  assert.equal(fields.last_task, 'reviewing');
+});


### PR DESCRIPTION
Petrus: *"Pi is also on mains power, no reason to not report temp and load = you should have it for all devices."*

`host` was a bare string on the agent record (`claudemm.host = "mac-mini"`), so the dashboard had nowhere to put a temperature or a load figure. This publishes it as an object.

**What each machine reports**

| | load | temp |
|---|---|---|
| macOS (Mac mini) | yes | no, `powermetrics` needs root |
| Linux (Pi) | yes | yes, from the thermal zones |

The Mac mini now publishes `{"machine":"mac-mini","load_1m":2.18,"cpu_count":10,"load_pct":22}` where it previously published the string `"mac-mini"`.

**Load is normalised against core count.** Raw loadavg is not comparable across a fleet: 1.8 is about 18% of a 10-core M4 but about 45% of a 4-core Pi. `load_pct` is the only figure that means the same thing on every device, and `load_1m` is kept alongside it.

**A sensor we cannot read is omitted, never zeroed.** A zero renders as a real reading, which makes an idle box and a broken sensor look identical. This matches the reader contract grok landed on the CodeWatch side (missing value omitted, not zeroed).

**macOS temperature is deliberately absent.** `powermetrics` requires root, there is no passwordless sudo on the Mini, and no non-root thermal sysctl is exposed on this M4. A long-running daemon shelling out to sudo for a dashboard number is not a trade I wanted to make silently. If we want Mac temperature, it needs a privilege decision from Petrus (a NOPASSWD sudoers entry, or a separately privileged helper), not a quiet workaround here.

**Testing.** 13 tests pass. The omit-not-zero contract was verified by planting a zero temperature and confirming two tests fail on it, then restoring.

Scope note: this is the shared Node publisher only. It does not touch grok's `presence.py` (different repo) or the Pi's publisher.

Requesting adversarial review before merge, per our cross-model review rule. Not merging this myself.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>