### PR TITLE
feat(uik): publish available memory, the figure a fit decision needs

### DIFF
--- a/packages/user-intent-kit/src/host-telemetry.js
+++ b/packages/user-intent-kit/src/host-telemetry.js
@@ -52,6 +52,23 @@ export const defaultSources = {
   cpuCount: () => cpus()?.length,
   totalMemBytes: () => totalmem(),
   freeMemBytes: () => freemem(),
+  // The OS's own view of what a new process could actually get. macOS reports
+  // it as a percentage; Linux exposes MemAvailable directly.
+  availableMemBytes: () => {
+    if (platform() === 'darwin') {
+      const pct = Number((run('/usr/bin/memory_pressure', []).match(/free percentage:\s*(\d+)%/) || [])[1]);
+      return Number.isFinite(pct) ? (totalmem() * pct) / 100 : undefined;
+    }
+    if (platform() === 'linux') {
+      try {
+        const kb = Number((readFileSync('/proc/meminfo', 'utf8').match(/MemAvailable:\s*(\d+)\s*kB/) || [])[1]);
+        return Number.isFinite(kb) ? kb * 1024 : undefined;
+      } catch {
+        return undefined;
+      }
+    }
+    return undefined;
+  },
   run,
   listThermalZones: () => readdirSync(THERMAL_ROOT).filter((z) => z.startsWith('thermal_zone')),
   readThermalZone: (zone) => readFileSync(`${THERMAL_ROOT}/${zone}/temp`, 'utf8'),
@@ -107,6 +124,16 @@ function readMemory(sources) {
   }
   if (Number.isFinite(free) && free >= 0) {
     out.mem_free_gb = Math.round((free / BYTES_PER_GB) * 10) / 10;
+  }
+
+  // What a new process could actually claim, which on macOS is nothing like
+  // `mem_free_gb`: this Mac reports 1.3 GB free and ~17 GB available, because
+  // the rest is cache the OS hands back on demand. Anything deciding whether a
+  // model fits must use this figure — free memory would say no on a machine
+  // with plenty.
+  const avail = sources.availableMemBytes?.();
+  if (Number.isFinite(avail) && avail >= 0) {
+    out.mem_available_gb = Math.round((avail / BYTES_PER_GB) * 10) / 10;
   }
   return out;
 }

--- a/packages/user-intent-kit/test/host-telemetry.test.js
+++ b/packages/user-intent-kit/test/host-telemetry.test.js
@@ -11,13 +11,14 @@ import { collectHostTelemetry } from '../src/host-telemetry.js';
  * and "tests pass" would say nothing about the Pi.
  */
 function sources({ platform = 'linux', load = [1.8, 1.7, 1.6], cpuCount = 4, zones = {},
-                   totalMem = 16e9, freeMem = 4e9, commands = {} } = {}) {
+                   totalMem = 16e9, freeMem = 4e9, availMem = 12e9, commands = {} } = {}) {
   return {
     platform: () => platform,
     loadavg: () => load,
     cpuCount: () => cpuCount,
     totalMemBytes: () => totalMem,
     freeMemBytes: () => freeMem,
+    availableMemBytes: () => availMem,
     run: (cmd, args) => {
       const key = `${cmd} ${(args || []).join(' ')}`;
       return (commands && commands[key]) || '';
@@ -229,4 +230,32 @@ test('omits hardware and network when the commands fail', () => {
   assert.ok(!('hw' in host), 'invented a hardware description');
   assert.ok(!('network' in host), 'guessed a network medium');
   assert.ok(!('lan_ip' in host));
+});
+
+// --- available memory: the figure that decides whether a model fits ---
+
+test('publishes available memory alongside free, not instead of it', () => {
+  const host = collectHostTelemetry({ sources: sources({ freeMem: 1.3e9, availMem: 17.8e9 }) });
+  assert.equal(host.mem_free_gb, 1.3);
+  assert.equal(host.mem_available_gb, 17.8);
+});
+
+test('available is what a model-fits decision must use', () => {
+  // A real Mac: 1.3 GB free, ~18 GB available. Deciding on free would refuse a
+  // model the machine can hold comfortably.
+  const host = collectHostTelemetry({ sources: sources({ totalMem: 25.8e9, freeMem: 1.3e9, availMem: 17.8e9 }) });
+  assert.ok(host.mem_available_gb > host.mem_free_gb * 10, 'the gap is the whole point');
+});
+
+test('omits available when the OS will not say', () => {
+  const blind = sources();
+  blind.availableMemBytes = () => undefined;
+  const host = collectHostTelemetry({ sources: blind });
+  assert.ok(!('mem_available_gb' in host), 'guessed an availability figure');
+  assert.ok('mem_total_gb' in host, 'and did not lose the rest');
+});
+
+test('zero available is a real reading', () => {
+  const host = collectHostTelemetry({ sources: sources({ availMem: 0 }) });
+  assert.equal(host.mem_available_gb, 0);
 });


### PR DESCRIPTION
Petrus is asking the dashboard to advise on running a local model, generalised to a size class and quant. That advice needs an accurate "how much memory can this box actually give a model" number, and the field I shipped this morning is not it.

On this Mini, right now:

| field | value |
|---|---|
| `mem_total_gb` | 25.8 |
| `mem_free_gb` | 1.5 |
| **`mem_available_gb`** | **18.0** |

`freemem()` counts only genuinely free pages; macOS keeps the rest as cache and hands it back on demand. A verdict computed from free memory would tell Petrus every Mac is out of memory while a 35B-A3B at 3-bit fits comfortably.

The new field asks the OS instead — the percentage `memory_pressure` reports on macOS, `MemAvailable` on Linux — and is published **alongside** free, not instead of it, because both are true and they answer different questions.

This is deliberately the field I declined to derive when I added memory: a used-percentage computed from `freemem()` would have been an alarm the numbers do not support. Asking the OS what is available is the honest form of that question.

39 tests pass, covering the gap itself, omission when the OS will not answer, and zero as a real reading.

Note for [#98](https://github.com/ThinkOffApp/antfarm/pull/98) (already merged): it correctly uses `mem_total_gb` and explicitly avoids `mem_free_gb`. This field gives it a better input on Macs than total-minus-a-guessed-reserve, if @grok wants it.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>