### PR TITLE
fix(uik): stop an unattended Mac claiming the user is sitting at it

### DIFF
--- a/packages/user-intent-kit/src/adapters/desktop.js
+++ b/packages/user-intent-kit/src/adapters/desktop.js
@@ -1,7 +1,10 @@
 // SPDX-License-Identifier: AGPL-3.0
 
-import { execSync } from 'node:child_process';
+import { execSync, execFileSync } from 'node:child_process';
 import { platform } from 'node:os';
+
+/** Idle longer than this and the user is not at this machine. */
+const IDLE_AFTER_SEC = 300;
 import { collectHostTelemetry } from '../host-telemetry.js';
 
 /**
@@ -61,13 +64,42 @@ export class DesktopAdapter {
     this.#client.stopHeartbeat();
   }
 
+  /**
+   * Seconds since the user last touched this machine, or undefined if the OS
+   * will not say. macOS keeps it in the HID system as nanoseconds.
+   */
+  #idleSeconds() {
+    if (platform() !== 'darwin') return undefined;
+    try {
+      const out = execFileSync('/usr/sbin/ioreg', ['-c', 'IOHIDSystem'], {
+        encoding: 'utf8',
+        timeout: 3000,
+        stdio: ['ignore', 'pipe', 'ignore'],
+      });
+      const ns = Number((out.match(/"HIDIdleTime"\s*=\s*(\d+)/) || [])[1]);
+      return Number.isFinite(ns) ? Math.round(ns / 1e9) : undefined;
+    } catch {
+      return undefined;
+    }
+  }
+
   #detectState() {
     // Vitals ride along with the desktop card so a machine's row shows what it
     // is and how it is doing, the same fields the Pi publishes — otherwise a
     // Mac appears in the fleet as a name and nothing else.
+    const idleSec = this.#idleSeconds();
+
+    // `screen_active` used to be hardcoded true. The derived state picks the
+    // most recently updated device whose screen is active as the one the user
+    // is on, and this daemon republishes every 30s — so an unattended Mac
+    // always won, and the dashboard told Petrus he was working at the Mac mini
+    // while he was on his phone. It had been untouched for 18 hours.
+    const active = idleSec === undefined ? true : idleSec < IDLE_AFTER_SEC;
+
     const state = {
-      screen_active: true,
-      context: 'active',
+      screen_active: active,
+      context: active ? 'active' : 'idle',
+      ...(idleSec === undefined ? {} : { idle_sec: idleSec }),
       ...collectHostTelemetry({ machine: this.#machine, kind: this.#kind }),
     };
 
@@ -79,11 +111,15 @@ export class DesktopAdapter {
         ).trim();
         state.active_app = app.toLowerCase();
 
-        // Infer context from active app
-        if (['zoom', 'microsoft teams', 'google meet', 'facetime', 'webex'].some(a => state.active_app.includes(a))) {
-          state.context = 'meeting';
-        } else if (['claude', 'codex', 'terminal', 'iterm', 'warp', 'code', 'cursor'].some(a => state.active_app.includes(a))) {
-          state.context = 'coding';
+        // Infer context from active app — but only when someone is actually
+        // at the machine. A frontmost editor on a box nobody has touched since
+        // yesterday is not "coding".
+        if (state.screen_active) {
+          if (['zoom', 'microsoft teams', 'google meet', 'facetime', 'webex'].some(a => state.active_app.includes(a))) {
+            state.context = 'meeting';
+          } else if (['claude', 'codex', 'terminal', 'iterm', 'warp', 'code', 'cursor'].some(a => state.active_app.includes(a))) {
+            state.context = 'coding';
+          }
         }
       }
     } catch {


### PR DESCRIPTION
Petrus: *"Why user intent has one box at the top saying i work on mac mini? I am on s26 ultra codewatch atm"*

`screen_active` was hardcoded `true`. The derived state picks **the most recently updated device whose screen is active** as the one the user is on, and this daemon republishes every 30 seconds — so an unattended Mac won that contest permanently.

Measured on the Mini while Petrus was on his phone:

```
HIDIdleTime = 64,570s  ≈ 17.9 hours untouched
published:   screen_active: true, context: "coding"
```

Now it reads the real idle time: active under five minutes, idle beyond, and publishes `idle_sec` so a card can show how long. The frontmost app only sets `coding`/`meeting` when someone is actually present — an editor in the foreground on a machine nobody has touched since yesterday is not coding.

After the change, same machine: `screen_active: false, context: "idle", idle_sec: 64613`.

Where the OS will not report idle time, the field stays `true` as before rather than guessing the user away.

**Necessary but not sufficient.** @grok measured that no S26 device publishes to UIK at all — live devices are macbook, mac-mini and vadelma, with clawwatch stale. So the phone still cannot be chosen as preferred once the Macs stop lying; that half is the CodeWatch client publishing device presence.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>