### PR TITLE
feat(team-relay): Linear issue feed on the existing event rails

### DIFF
--- a/bin/cli.mjs
+++ b/bin/cli.mjs
@@ -14,6 +14,7 @@ import { tailReceipts } from '../src/team-relay/receipt.mjs';
 import { startWebhookServer } from '../src/team-relay/webhook-server.mjs';
 import { emitJson } from '../src/team-relay/emit.mjs';
 import { startRoomPoller, checkRoomMessages } from '../src/team-relay/room-poller.mjs';
+import { startLinearPoller } from '../src/team-relay/linear-poller.mjs';
 import { memoryList, memoryGet, memorySet, memoryAppend, memoryDelete, memorySearch } from '../src/team-relay/memory.mjs';
 import { moltbookPost, moltbookFeed } from '../src/team-relay/moltbook.mjs';
 import { startRoomAutomation } from '../src/team-relay/room-automation.mjs';
@@ -268,9 +269,14 @@ async function main() {
   if (command === 'serve') {
     const opts = parseKV(args, 'serve');
     const config = loadConfig(opts.config);
-    startWebhookServer(config, (event) => {
+    const onEvent = (event) => {
       console.log(`Event queued: ${event.kind} (${event.trace_id})`);
-    });
+    };
+    startWebhookServer(config, onEvent);
+    // Linear issues ride the same callback as GitHub events. Disabled by
+    // default: with no token file the poller logs and returns a no-op handle,
+    // so installs without Linear are unaffected.
+    startLinearPoller(config.linear || {}, onEvent);
     return;
   }
 

--- a/src/team-relay/linear-poller.mjs
+++ b/src/team-relay/linear-poller.mjs
@@ -77,15 +77,29 @@ const ISSUES_QUERY = `
  * has no created/updated event split on this query, and comparing the two
  * timestamps is more reliable than remembering which ids we have seen: a state
  * store can be lost, but the issue's own timestamps cannot.
+ *
+ * On actor.login, which is deliberately narrow (found by @codexmb reviewing
+ * PR #69): for a CREATED issue the creator really is the actor. For an UPDATED
+ * one we do not know who made the change. The assignee is a tempting stand-in
+ * and is wrong: an issue assigned to Petrus and edited by an agent would be
+ * attributed to Petrus, and "who did what" is the whole reason this feed
+ * exists. Linear's issue history would carry the real actor, but it comes back
+ * empty for issues created through an API token, so it cannot be relied on.
+ *
+ * So an update reports 'unknown' rather than a plausible lie. The assignee and
+ * creator still travel in the payload, where they are labelled as what they
+ * actually are.
  */
 export function buildLinearEvent(issue) {
   const isNew = issue.createdAt === issue.updatedAt;
+  const creator = issue.creator?.displayName || null;
+  const assignee = issue.assignee?.displayName || null;
   return {
     trace_id: randomUUID(),
     source: 'linear',
     kind: isNew ? 'linear.issue.created' : 'linear.issue.updated',
     timestamp: issue.updatedAt,
-    actor: { login: issue.assignee?.displayName || issue.creator?.displayName || 'unknown' },
+    actor: { login: isNew ? creator || 'unknown' : 'unknown' },
     refs: {
       issue_url: issue.url,
       issue_identifier: issue.identifier,
@@ -95,7 +109,9 @@ export function buildLinearEvent(issue) {
       title: (issue.title || '').slice(0, 300),
       state: issue.state?.name,
       state_type: issue.state?.type,
-      priority: issue.priority
+      priority: issue.priority,
+      assignee,
+      creator
     }
   };
 }

--- a/src/team-relay/linear-poller.mjs
+++ b/src/team-relay/linear-poller.mjs
@@ -1,0 +1,164 @@
+/**
+ * Linear issue feed.
+ *
+ * Puts Linear issues on the same rails GitHub PRs already ride: this emits the
+ * exact event shape webhook-server.mjs produces, so every consumer downstream
+ * (CodeWatch included) treats a Linear issue like any other event and needs no
+ * special case.
+ *
+ * Polling, not a webhook, and that is deliberate. A webhook needs a stable
+ * public URL, and this fleet reaches the outside through a tunnel whose URL
+ * rotates on every restart. A webhook would die silently at each rotation and
+ * nobody would notice until issues quietly stopped arriving. Polling owns its
+ * own liveness: no inbound URL, nothing to re-point, and a failed poll is
+ * visible in the log immediately. Issue tracking does not need sub-minute
+ * latency, so the trade costs nothing that matters.
+ *
+ * Read-only by construction. It holds a Linear API key and never calls a
+ * mutation, so the worst a bug here can do is emit a wrong event.
+ */
+
+import { randomUUID } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+const LINEAR_API = 'https://api.linear.app/graphql';
+const DEFAULT_TOKEN_FILE = join(homedir(), '.config', 'linear.token');
+const DEFAULT_INTERVAL_MS = 120000;
+
+/**
+ * The token comes from a file, never from config or argv.
+ *
+ * Anything on a command line reaches a process list and a shell history, and on
+ * this fleet the precommand gate has posted a command into the room and leaked
+ * a key exactly that way. A path in config is safe to commit; a key is not.
+ */
+export function readLinearToken(tokenFile = DEFAULT_TOKEN_FILE) {
+  try {
+    const raw = readFileSync(tokenFile, 'utf8').trim();
+    return raw || null;
+  } catch {
+    return null;
+  }
+}
+
+async function linearQuery(token, query, variables = {}) {
+  const res = await fetch(LINEAR_API, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Authorization: token },
+    body: JSON.stringify({ query, variables })
+  });
+  if (!res.ok) throw new Error(`linear http ${res.status}`);
+  const body = await res.json();
+  if (body.errors?.length) throw new Error(`linear: ${body.errors[0].message}`);
+  return body.data;
+}
+
+const ISSUES_QUERY = `
+  query($since: DateTimeOrDuration!, $first: Int!) {
+    issues(
+      filter: { updatedAt: { gt: $since } }
+      orderBy: updatedAt
+      first: $first
+    ) {
+      nodes {
+        id identifier title url priority createdAt updatedAt
+        state { name type }
+        assignee { displayName }
+        creator { displayName }
+        team { key }
+      }
+    }
+  }`;
+
+/**
+ * An issue is "new" when it has not been updated since it was created. Linear
+ * has no created/updated event split on this query, and comparing the two
+ * timestamps is more reliable than remembering which ids we have seen: a state
+ * store can be lost, but the issue's own timestamps cannot.
+ */
+export function buildLinearEvent(issue) {
+  const isNew = issue.createdAt === issue.updatedAt;
+  return {
+    trace_id: randomUUID(),
+    source: 'linear',
+    kind: isNew ? 'linear.issue.created' : 'linear.issue.updated',
+    timestamp: issue.updatedAt,
+    actor: { login: issue.assignee?.displayName || issue.creator?.displayName || 'unknown' },
+    refs: {
+      issue_url: issue.url,
+      issue_identifier: issue.identifier,
+      team: issue.team?.key
+    },
+    payload: {
+      title: (issue.title || '').slice(0, 300),
+      state: issue.state?.name,
+      state_type: issue.state?.type,
+      priority: issue.priority
+    }
+  };
+}
+
+/**
+ * Poll for issues changed since `since`, emit one event each, and return the
+ * newest updatedAt seen so the caller can advance its cursor.
+ *
+ * The cursor moves ONLY past issues actually emitted. If onEvent throws, the
+ * cursor stays put and that issue is retried next tick, because losing an
+ * update silently is worse than emitting it twice.
+ */
+export async function pollOnce(token, since, onEvent, { first = 50 } = {}) {
+  const data = await linearQuery(token, ISSUES_QUERY, { since, first });
+  const nodes = data?.issues?.nodes || [];
+  let cursor = since;
+  for (const issue of nodes) {
+    const event = buildLinearEvent(issue);
+    if (onEvent) await onEvent(event);
+    if (issue.updatedAt > cursor) cursor = issue.updatedAt;
+  }
+  return { cursor, count: nodes.length };
+}
+
+export function startLinearPoller(config = {}, onEvent) {
+  const tokenFile = config.token_file || DEFAULT_TOKEN_FILE;
+  const intervalMs = config.interval_ms || DEFAULT_INTERVAL_MS;
+  const token = readLinearToken(tokenFile);
+
+  if (!token) {
+    // Absent config is not an error: most installs have no Linear at all, and a
+    // relay must not fail to start because an optional feed is unconfigured.
+    console.log(`[linear] no token at ${tokenFile}, feed disabled`);
+    return { stop() {} };
+  }
+
+  // Start from now, not from the beginning of time. On a cold start every open
+  // issue looks updated, and without this the first tick replays the entire
+  // backlog into the room at once.
+  let cursor = config.since || new Date().toISOString();
+  let timer = null;
+  let stopped = false;
+
+  async function tick() {
+    try {
+      const { cursor: next, count } = await pollOnce(token, cursor, onEvent);
+      if (count > 0) console.log(`[linear] ${count} issue(s) since ${cursor}`);
+      cursor = next;
+    } catch (err) {
+      // Keep polling. A transient Linear outage or a rotated key must not kill
+      // the relay; the log says what happened and the next tick retries.
+      console.error(`[linear] poll failed: ${err.message}`);
+    }
+    if (!stopped) timer = setTimeout(tick, intervalMs);
+  }
+
+  console.log(`[linear] feed on, polling every ${Math.round(intervalMs / 1000)}s`);
+  timer = setTimeout(tick, intervalMs);
+
+  return {
+    stop() {
+      stopped = true;
+      if (timer) clearTimeout(timer);
+    }
+  };
+}

--- a/src/team-relay/linear-poller.mjs
+++ b/src/team-relay/linear-poller.mjs
@@ -56,11 +56,12 @@ async function linearQuery(token, query, variables = {}) {
 }
 
 const ISSUES_QUERY = `
-  query($since: DateTimeOrDuration!, $first: Int!) {
+  query($since: DateTimeOrDuration!, $first: Int!, $after: String) {
     issues(
       filter: { updatedAt: { gt: $since } }
       orderBy: updatedAt
       first: $first
+      after: $after
     ) {
       nodes {
         id identifier title url priority createdAt updatedAt
@@ -69,6 +70,7 @@ const ISSUES_QUERY = `
         creator { displayName }
         team { key }
       }
+      pageInfo { hasNextPage endCursor }
     }
   }`;
 
@@ -123,17 +125,43 @@ export function buildLinearEvent(issue) {
  * The cursor moves ONLY past issues actually emitted. If onEvent throws, the
  * cursor stays put and that issue is retried next tick, because losing an
  * update silently is worse than emitting it twice.
+ *
+ * Every page is drained before returning, and that is the point rather than an
+ * optimisation (found by @codexmb reviewing PR #69). The cursor is a timestamp
+ * and the filter is strictly `updatedAt > cursor`, so any issue sharing the
+ * last emitted timestamp would be excluded from the next poll. Stopping at a
+ * page boundary would therefore skip tied issues PERMANENTLY, not just delay
+ * them: a bulk edit touching more than one page of issues in the same second
+ * would silently lose the remainder. Draining means the cursor only ever lands
+ * past a timestamp whose issues have all been emitted.
+ *
+ * maxPages is a runaway guard, not a limit anyone should hit. If it trips, the
+ * cursor still holds at the last fully-emitted position, so the next tick
+ * resumes rather than skipping.
  */
-export async function pollOnce(token, since, onEvent, { first = 50 } = {}) {
-  const data = await linearQuery(token, ISSUES_QUERY, { since, first });
-  const nodes = data?.issues?.nodes || [];
+export async function pollOnce(token, since, onEvent, { first = 50, maxPages = 20 } = {}) {
   let cursor = since;
-  for (const issue of nodes) {
-    const event = buildLinearEvent(issue);
-    if (onEvent) await onEvent(event);
-    if (issue.updatedAt > cursor) cursor = issue.updatedAt;
+  let after = null;
+  let count = 0;
+
+  for (let page = 0; page < maxPages; page++) {
+    const data = await linearQuery(token, ISSUES_QUERY, { since, first, after });
+    const nodes = data?.issues?.nodes || [];
+    const info = data?.issues?.pageInfo || {};
+
+    for (const issue of nodes) {
+      const event = buildLinearEvent(issue);
+      if (onEvent) await onEvent(event);
+      count++;
+      if (issue.updatedAt > cursor) cursor = issue.updatedAt;
+    }
+
+    if (!info.hasNextPage || !info.endCursor) return { cursor, count };
+    after = info.endCursor;
   }
-  return { cursor, count: nodes.length };
+
+  console.error(`[linear] stopped after ${maxPages} pages, resuming from ${cursor} next tick`);
+  return { cursor, count };
 }
 
 export function startLinearPoller(config = {}, onEvent) {

--- a/test/linear-poller.test.mjs
+++ b/test/linear-poller.test.mjs
@@ -1,0 +1,82 @@
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  buildLinearEvent,
+  readLinearToken,
+  startLinearPoller
+} from '../src/team-relay/linear-poller.mjs';
+
+const issue = (over = {}) => ({
+  id: 'abc',
+  identifier: 'THI-42',
+  title: 'Something broke',
+  url: 'https://linear.app/thinkoff/issue/THI-42/something-broke',
+  priority: 2,
+  createdAt: '2026-08-27T06:00:00.000Z',
+  updatedAt: '2026-08-27T06:00:00.000Z',
+  state: { name: 'Backlog', type: 'backlog' },
+  assignee: { displayName: 'Petrus' },
+  creator: { displayName: 'claudemm' },
+  team: { key: 'THI' },
+  ...over
+});
+
+describe('linear poller', () => {
+  it('emits the same event shape the webhook server produces', () => {
+    const e = buildLinearEvent(issue());
+    // Consumers downstream switch on these keys. A Linear event that is missing
+    // one would be dropped silently rather than loudly, so assert the contract.
+    for (const key of ['trace_id', 'source', 'kind', 'timestamp', 'actor', 'refs', 'payload']) {
+      assert.ok(key in e, `missing ${key}`);
+    }
+    assert.equal(e.source, 'linear');
+    assert.equal(e.refs.issue_identifier, 'THI-42');
+    assert.equal(e.payload.state, 'Backlog');
+  });
+
+  it('calls an unchanged issue created, and a touched one updated', () => {
+    assert.equal(buildLinearEvent(issue()).kind, 'linear.issue.created');
+    const touched = issue({ updatedAt: '2026-08-27T07:00:00.000Z' });
+    assert.equal(buildLinearEvent(touched).kind, 'linear.issue.updated');
+  });
+
+  it('falls back through assignee, creator, then unknown', () => {
+    assert.equal(buildLinearEvent(issue()).actor.login, 'Petrus');
+    assert.equal(buildLinearEvent(issue({ assignee: null })).actor.login, 'claudemm');
+    assert.equal(
+      buildLinearEvent(issue({ assignee: null, creator: null })).actor.login,
+      'unknown'
+    );
+  });
+
+  it('truncates a long title so one issue cannot flood the relay', () => {
+    const e = buildLinearEvent(issue({ title: 'x'.repeat(5000) }));
+    assert.equal(e.payload.title.length, 300);
+  });
+
+  it('returns null rather than throwing when the token file is absent', () => {
+    assert.equal(readLinearToken(join(tmpdir(), 'definitely-not-here.token')), null);
+  });
+
+  it('reads a token from a file', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'linear-'));
+    const f = join(dir, 'linear.token');
+    writeFileSync(f, '  lin_api_example  \n');
+    assert.equal(readLinearToken(f), 'lin_api_example');
+  });
+
+  it('starts disabled instead of throwing when unconfigured', () => {
+    // Most installs have no Linear. An optional feed must never stop the relay
+    // from coming up.
+    const handle = startLinearPoller(
+      { token_file: join(tmpdir(), 'definitely-not-here.token') },
+      () => {}
+    );
+    assert.equal(typeof handle.stop, 'function');
+    handle.stop();
+  });
+});

--- a/test/linear-poller.test.mjs
+++ b/test/linear-poller.test.mjs
@@ -124,4 +124,71 @@ describe('linear poller', () => {
     assert.equal(typeof handle.stop, 'function');
     handle.stop();
   });
+
+  it('drains every page, so issues tied at a page boundary are not skipped forever', async () => {
+    // The filter is strictly updatedAt > cursor. If a poll stopped at a page
+    // boundary, any issue sharing that last timestamp would be excluded from
+    // the NEXT poll too, and lost permanently rather than merely delayed.
+    const tied = '2026-08-27T06:00:00.000Z';
+    const page1 = [issue({ identifier: 'THI-1', updatedAt: tied })];
+    const page2 = [issue({ identifier: 'THI-2', updatedAt: tied })];
+    let call = 0;
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async () => {
+      call++;
+      const first = call === 1;
+      return {
+        ok: true,
+        json: async () => ({
+          data: {
+            issues: {
+              nodes: first ? page1 : page2,
+              pageInfo: { hasNextPage: first, endCursor: first ? 'cur1' : null }
+            }
+          }
+        })
+      };
+    };
+    try {
+      const seen = [];
+      const { count } = await pollOnce('tok', '2026-08-27T05:00:00.000Z', (e) => {
+        seen.push(e.refs.issue_identifier);
+      });
+      assert.equal(count, 2);
+      assert.deepEqual(seen, ['THI-1', 'THI-2']);
+      assert.equal(call, 2, 'should have fetched the second page');
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('stops at maxPages and holds the cursor so the next tick resumes', async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async () => ({
+      ok: true,
+      json: async () => ({
+        data: {
+          issues: {
+            nodes: [issue({ updatedAt: '2026-08-27T06:00:00.000Z' })],
+            pageInfo: { hasNextPage: true, endCursor: 'always-more' }
+          }
+        }
+      })
+    });
+    try {
+      const { count } = await pollOnce('tok', '2026-08-27T05:00:00.000Z', () => {}, { maxPages: 3 });
+      assert.equal(count, 3, 'guard should stop the loop rather than spin');
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('treats identical create/update timestamps as created, and any drift as updated', () => {
+    // Documents the invariant codexmb asked about: the heuristic is equality on
+    // the exact strings Linear returns. Sub-second drift means updated, which is
+    // the safe direction: a real edit is never mislabelled as a creation.
+    assert.equal(buildLinearEvent(issue()).kind, 'linear.issue.created');
+    const drift = issue({ updatedAt: '2026-08-27T06:00:00.001Z' });
+    assert.equal(buildLinearEvent(drift).kind, 'linear.issue.updated');
+  });
 });

--- a/test/linear-poller.test.mjs
+++ b/test/linear-poller.test.mjs
@@ -6,6 +6,7 @@ import { join } from 'node:path';
 
 import {
   buildLinearEvent,
+  pollOnce,
   readLinearToken,
   startLinearPoller
 } from '../src/team-relay/linear-poller.mjs';
@@ -44,11 +45,10 @@ describe('linear poller', () => {
     assert.equal(buildLinearEvent(touched).kind, 'linear.issue.updated');
   });
 
-  it('falls back through assignee, creator, then unknown', () => {
-    assert.equal(buildLinearEvent(issue()).actor.login, 'Petrus');
-    assert.equal(buildLinearEvent(issue({ assignee: null })).actor.login, 'claudemm');
+  it('falls back to unknown when a created issue has no creator', () => {
+    assert.equal(buildLinearEvent(issue()).actor.login, 'claudemm');
     assert.equal(
-      buildLinearEvent(issue({ assignee: null, creator: null })).actor.login,
+      buildLinearEvent(issue({ creator: null })).actor.login,
       'unknown'
     );
   });
@@ -67,6 +67,51 @@ describe('linear poller', () => {
     const f = join(dir, 'linear.token');
     writeFileSync(f, '  lin_api_example  \n');
     assert.equal(readLinearToken(f), 'lin_api_example');
+  });
+
+  it('reports an update actor as unknown rather than blaming the assignee', () => {
+    // The assignee is not who made the change. Attributing an edit to whoever
+    // happens to be assigned is the exact "who did what" error this feed exists
+    // to avoid, so an update says unknown and puts the names in the payload.
+    const touched = issue({ updatedAt: '2026-08-27T07:00:00.000Z' });
+    const e = buildLinearEvent(touched);
+    assert.equal(e.kind, 'linear.issue.updated');
+    assert.equal(e.actor.login, 'unknown');
+    assert.equal(e.payload.assignee, 'Petrus');
+    assert.equal(e.payload.creator, 'claudemm');
+  });
+
+  it('credits the creator on a created issue, where it is genuinely the actor', () => {
+    const e = buildLinearEvent(issue({ assignee: { displayName: 'Someone Else' } }));
+    assert.equal(e.kind, 'linear.issue.created');
+    assert.equal(e.actor.login, 'claudemm');
+  });
+
+  it('leaves the cursor unmoved when the consumer throws, so the issue retries', async () => {
+    // Losing an update silently is worse than emitting it twice.
+    const since = '2026-08-27T05:00:00.000Z';
+    const nodes = [issue({ updatedAt: '2026-08-27T06:00:00.000Z' })];
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async () => ({
+      ok: true,
+      json: async () => ({ data: { issues: { nodes } } })
+    });
+    try {
+      await assert.rejects(
+        () => pollOnce('tok', since, () => { throw new Error('consumer down'); }),
+        /consumer down/
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('is wired into `iak serve`, not just exported', async () => {
+    // A poller nothing calls emits nothing. Assert the CLI actually starts it.
+    const { readFileSync } = await import('node:fs');
+    const cli = readFileSync(new URL('../bin/cli.mjs', import.meta.url), 'utf8');
+    assert.match(cli, /import \{ startLinearPoller \}/);
+    assert.match(cli, /startLinearPoller\(/);
   });
 
   it('starts disabled instead of throwing when unconfigured', () => {


### PR DESCRIPTION
Puts Linear issues on the rails GitHub PRs already ride, so they reach CodeWatch without any consumer needing a special case.

## What it does
`startLinearPoller(config, onEvent)` emits the **same event shape** `webhook-server.mjs` produces: `{trace_id, source, kind, timestamp, actor, refs, payload}`. Kinds are `linear.issue.created` and `linear.issue.updated`.

## Why polling, not a webhook
A webhook needs a stable public URL. This fleet reaches the outside through a tunnel whose URL rotates on every restart, so the hook would die silently at each rotation and nobody would notice until issues quietly stopped arriving — we already live with that failure mode elsewhere. Polling owns its own liveness: no inbound URL, nothing to re-point, and a failed poll is in the log immediately. Issue tracking does not need sub-minute latency, so the trade costs nothing that matters.

## Safety
- **Read-only by construction.** It holds a Linear key and never calls a mutation, so the worst a bug here can do is emit a wrong event.
- **Token from a file**, never config or argv (`~/.config/linear.token` by default). The precommand gate has echoed a command into the room and leaked a key exactly that way. A path is safe to commit; a key is not.
- **Missing token disables the feed** rather than failing the relay — most installs have no Linear.
- **Cursor starts at now**, not epoch, so a cold start does not replay the whole backlog into the room.
- **Cursor only advances past emitted issues**, so a throwing consumer causes a retry rather than a silent loss.

## Verification
- 7 unit tests, all passing (`node --test test/linear-poller.test.mjs`).
- Smoke-tested against the live Linear API: 15 issues in the last hour, correctly split into created vs updated (THI-17 had been edited and came through as `updated`; THI-16/18/19 as `created`).
- Neighbouring `webhook.test.mjs` suite still passes (4/4).

## Not included
Chaining a Linear state change to a PR merge. That is a write action against GitHub and wants an explicit decision plus gating (linked PR, mergeable, CI green, explicit "Merge approved" state) — deliberately out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)