### PR TITLE
groupmind poller: carry reply_to and resolve reply targets into agent-facing lines

### DIFF
--- a/src/adapters/groupmind.mjs
+++ b/src/adapters/groupmind.mjs
@@ -25,8 +25,18 @@ export const groupmindAdapter = {
         });
         const data = JSON.parse(result);
         const msgs = data.messages || (Array.isArray(data) ? data : []);
+        // Resolve reply targets from the same batch: a fresh reply's target is
+        // almost always within the last `limit` messages. Without this the
+        // reply_to id survives but means nothing to a reader of the line.
+        // (Aug 27 2026: petrus's "spec this" reply was interpreted by guess
+        // because every agent-facing surface dropped the reply target.)
+        const byId = new Map(msgs.map((m) => [m.id, m]));
         for (const m of msgs) {
           m._room = room;
+          if (m.reply_to && byId.has(m.reply_to)) {
+            const t = byId.get(m.reply_to);
+            m._replyTarget = { from: t.from || t.sender || '?', body: (t.body || '').slice(0, 120) };
+          }
         }
         all.push(...msgs);
       } catch (e) {
@@ -60,7 +70,13 @@ export const groupmindAdapter = {
       timestamp: ts,
       room,
       actor: { login: sender },
-      payload: { body, room }
+      payload: {
+        body,
+        room,
+        // A reply's meaning lives in its target - carry it, never drop it.
+        reply_to: msg.reply_to || null,
+        reply_target: msg._replyTarget || null
+      }
     };
   },
 
@@ -69,6 +85,17 @@ export const groupmindAdapter = {
     const sender = event.actor?.login || '?';
     const room = event.room || '';
     const body = (event.payload?.body || '').replace(/\n/g, ' ').slice(0, 200);
-    return `[${ts}] [${room}] ${sender}: ${body}`;
+    const line = `[${ts}] [${room}] ${sender}: ${body}`;
+    const t = event.payload?.reply_target;
+    if (t) {
+      const snippet = (t.body || '').replace(/\n/g, ' ').slice(0, 100);
+      return `${line}\n    ⤷ in reply to ${t.from}: "${snippet}"`;
+    }
+    if (event.payload?.reply_to) {
+      // Target not in the fetch window - still say it IS a reply so nobody
+      // interprets it as a freestanding statement.
+      return `${line}\n    ⤷ a reply (target ${event.payload.reply_to} not in recent window)`;
+    }
+    return line;
   }
 };

--- a/test/unified-poller.test.mjs
+++ b/test/unified-poller.test.mjs
@@ -141,3 +141,40 @@ describe('common/event-queue', () => {
     assert.equal(typeof appendEvents, 'function');
   });
 });
+
+describe('groupmind reply targets', () => {
+  // A reply's meaning lives in its target (Aug 27 2026: "spec this" was
+  // interpreted by guess because every agent surface dropped reply_to).
+  const target = { id: 'aaa', from: '@claudeMB', body: 'the AgentOS fleet message', created_at: '2026-08-27T08:06:00Z' };
+  const reply = { id: 'bbb', from: 'petrus', body: 'Great! Please spec this.', reply_to: 'aaa', created_at: '2026-08-27T08:41:00Z', _room: 'thinkoff-development' };
+
+  it('normalize carries reply_to and resolved reply_target', () => {
+    const withTarget = { ...reply, _replyTarget: { from: target.from, body: target.body } };
+    const ev = groupmindAdapter.normalize(withTarget, { poller: { handle: '@test' } });
+    assert.equal(ev.payload.reply_to, 'aaa');
+    assert.equal(ev.payload.reply_target.from, '@claudeMB');
+  });
+
+  it('formatLine shows the resolved reply target', () => {
+    const withTarget = { ...reply, _replyTarget: { from: target.from, body: target.body } };
+    const ev = groupmindAdapter.normalize(withTarget, { poller: { handle: '@test' } });
+    const line = groupmindAdapter.formatLine(ev);
+    assert.ok(line.includes('in reply to @claudeMB'), line);
+    assert.ok(line.includes('the AgentOS fleet message'), line);
+  });
+
+  it('formatLine marks an unresolved reply as a reply, never freestanding', () => {
+    const ev = groupmindAdapter.normalize(reply, { poller: { handle: '@test' } });
+    const line = groupmindAdapter.formatLine(ev);
+    assert.ok(line.includes('a reply'), line);
+    assert.ok(line.includes('bbb') === false, 'target id, not own id');
+    assert.ok(line.includes('aaa'), line);
+  });
+
+  it('non-replies keep the plain single-line format', () => {
+    const ev = groupmindAdapter.normalize(target, { poller: { handle: '@test' } });
+    const line = groupmindAdapter.formatLine(ev);
+    assert.ok(!line.includes('reply'), line);
+    assert.ok(!line.includes('\n'), line);
+  });
+});


### PR DESCRIPTION
## What

The GroupMind poller adapter dropped `reply_to` in `normalize()`, so every agent-facing surface showed replies as freestanding statements. Today that made "Great! Please spec this" (a reply to a specific message) get interpreted by guess, and the wrong spec was built (THI-26 / the AgentOS mixup).

The client always sent `reply_to`; the server stores and returns it. The drop was here.

## How

- `fetch()`: resolves reply targets from the same poll batch (a fresh reply's target is nearly always within the window)
- `normalize()`: payload now carries `reply_to` + resolved `reply_target {from, body}`
- `formatLine()`: renders `⤷ in reply to <from>: "<snippet>"`; an unresolved reply is still marked as a reply with its target id, never shown freestanding

## Tests

4 new regression tests (resolved, unresolved, non-reply formats); full suite 210/210.

Part of THI-19's re-aim (agent-side reply reading). The remaining half - the Android app's vanishing reply preview - is a separate CodeWatch client fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
