### PR TITLE
fix(poller): reply_to polymorphism + single-line reply annotation

### DIFF
--- a/src/adapters/groupmind.mjs
+++ b/src/adapters/groupmind.mjs
@@ -34,10 +34,22 @@ export const groupmindAdapter = {
         const byId = new Map(msgs.map((m) => [m.id, m]));
         for (const m of msgs) {
           m._room = room;
-          if (m.reply_to && byId.has(m.reply_to)) {
-            const t = byId.get(m.reply_to);
+          // reply_to is POLYMORPHIC: some clients POST a bare id string, others
+          // the object form { id, from, body } the server also stores verbatim.
+          // The object form used to miss the Map lookup and print
+          // "[object Object]" in agent-facing lines — the richest form of the
+          // data produced the worst output. Normalise before resolving.
+          const rt = m.reply_to;
+          const rtId = rt && typeof rt === 'object' ? rt.id : rt;
+          if (rtId && byId.has(rtId)) {
+            const t = byId.get(rtId);
             m._replyTarget = { from: t.from || t.sender || '?', body: (t.body || '').slice(0, 120) };
+          } else if (rt && typeof rt === 'object' && (rt.from || rt.body)) {
+            // Target outside the fetch window, but the object form carries it
+            // inline — use what the sender gave us.
+            m._replyTarget = { from: rt.from || '?', body: (rt.body || '').slice(0, 120) };
           }
+          if (rtId) m._replyToId = rtId;
         }
         all.push(...msgs);
       } catch (e) {
@@ -75,7 +87,11 @@ export const groupmindAdapter = {
         body,
         room,
         // A reply's meaning lives in its target - carry it, never drop it.
-        reply_to: msg.reply_to || null,
+        // Always the id string whatever shape arrived on the wire, so
+        // consumers never branch on client format.
+        reply_to: msg._replyToId
+          || (typeof msg.reply_to === 'object' ? (msg.reply_to?.id || null) : msg.reply_to)
+          || null,
         reply_target: msg._replyTarget || null
       }
     };
@@ -87,15 +103,19 @@ export const groupmindAdapter = {
     const room = event.room || '';
     const body = (event.payload?.body || '').replace(/\n/g, ' ').slice(0, 200);
     const line = `[${ts}] [${room}] ${sender}: ${body}`;
+    // ONE physical line, always. The notification file's readers split on
+    // newlines (and room_ack can clear the file mid-write), so a two-line
+    // entry became two half-events — one of them a freestanding "⤷" fragment.
+    // Found in review of #70 after merge; the annotation now rides inline.
     const t = event.payload?.reply_target;
     if (t) {
       const snippet = (t.body || '').replace(/\n/g, ' ').slice(0, 100);
-      return `${line}\n    ⤷ in reply to ${t.from}: "${snippet}"`;
+      return `${line}  ⤷ in reply to ${t.from}: "${snippet}"`;
     }
     if (event.payload?.reply_to) {
-      // Target not in the fetch window - still say it IS a reply so nobody
+      // Target not in the fetch window — still say it IS a reply so nobody
       // interprets it as a freestanding statement.
-      return `${line}\n    ⤷ a reply (target ${event.payload.reply_to} not in recent window)`;
+      return `${line}  ⤷ a reply (target ${event.payload.reply_to} not in recent window)`;
     }
     return line;
   }

--- a/test/unified-poller.test.mjs
+++ b/test/unified-poller.test.mjs
@@ -161,6 +161,7 @@ describe('groupmind reply targets', () => {
     const line = groupmindAdapter.formatLine(ev);
     assert.ok(line.includes('in reply to @claudeMB'), line);
     assert.ok(line.includes('the AgentOS fleet message'), line);
+    assert.ok(!line.includes('\n'), 'single line: ' + JSON.stringify(line));
   });
 
   it('formatLine marks an unresolved reply as a reply, never freestanding', () => {
@@ -176,5 +177,45 @@ describe('groupmind reply targets', () => {
     const line = groupmindAdapter.formatLine(ev);
     assert.ok(!line.includes('reply'), line);
     assert.ok(!line.includes('\n'), line);
+  });
+});
+
+describe('groupmind reply_to polymorphism and single-line format', () => {
+  // reply_to arrives as a bare id string OR as { id, from, body } depending on
+  // the client. Found reviewing #70 (merged before the fix): the object form
+  // printed "[object Object]". And formatLine must stay ONE physical line —
+  // notification readers split on newlines, so a two-line entry became two
+  // half-events.
+  it('object-form reply_to resolves and payload carries the id string', () => {
+    const reply = { id: 'bbb', from: 'petrus', body: 'spec this', created_at: '2026-08-27T08:41:00Z',
+      reply_to: { id: 'aaa', from: '@claudeMB', body: 'the AgentOS fleet message' },
+      _replyTarget: { from: '@claudeMB', body: 'the AgentOS fleet message' }, _replyToId: 'aaa' };
+    const ev = groupmindAdapter.normalize(reply, { poller: { handle: '@test' } });
+    assert.equal(ev.payload.reply_to, 'aaa');
+    const line = groupmindAdapter.formatLine(ev);
+    assert.ok(!line.includes('[object Object]'), line);
+    assert.ok(!line.includes('\n'), 'must be one physical line: ' + JSON.stringify(line));
+    assert.ok(line.includes('in reply to @claudeMB'), line);
+  });
+
+  it('object-form outside the window never prints [object Object] and stays one line', () => {
+    const reply = { id: 'bbb', from: 'petrus', body: 'spec this', created_at: '2026-08-27T08:41:00Z',
+      reply_to: { id: 'zzz' }, _replyToId: 'zzz' };
+    const ev = groupmindAdapter.normalize(reply, { poller: { handle: '@test' } });
+    assert.equal(ev.payload.reply_to, 'zzz');
+    const line = groupmindAdapter.formatLine(ev);
+    assert.ok(!line.includes('[object Object]'), line);
+    assert.ok(!line.includes('\n'), line);
+    assert.ok(line.includes('zzz'), line);
+  });
+
+  it('string-form reply with resolved target is one line with the annotation inline', () => {
+    const reply = { id: 'bbb', from: 'petrus', body: 'Great! Please spec this.', created_at: '2026-08-27T08:41:00Z',
+      reply_to: 'aaa', _replyToId: 'aaa',
+      _replyTarget: { from: '@claudeMB', body: 'the AgentOS fleet message' } };
+    const ev = groupmindAdapter.normalize(reply, { poller: { handle: '@test' } });
+    const line = groupmindAdapter.formatLine(ev);
+    assert.ok(!line.includes('\n'), line);
+    assert.ok(line.includes('in reply to @claudeMB'), line);
   });
 });


### PR DESCRIPTION
Fixes both review findings on #70 that merged before the fixes could land.

**1. Polymorphic reply_to** (claudemm's finding): the field arrives as a bare id string or as `{ id, from, body }` depending on the client; the server stores whatever was POSTed. The object form missed the `Map` lookup and printed `target [object Object] not in recent window`. Now normalised — lookup by id, inline from/body used when the target is outside the window, and `payload.reply_to` is always the id string.

**2. Two-line entries** (codexmb's finding): notification-file readers split on newlines, so a reply became two half-events, one of them a freestanding ⤷ fragment — and room_ack clearing the file mid-write could orphan the annotation. The annotation now rides inline on one physical line.

Not addressed here (bigger, tracked in the review): the legacy `rooms watch` path in `room-poller.mjs` still bypasses this adapter entirely.

Tests: 3 new cases (object-form resolved, object-form out-of-window, single-line invariant), touched suite 26/26, full tree green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)