### PR TITLE
reply targets: polymorphic reply_to, single-line contract, legacy poller parity

### DIFF
--- a/src/adapters/groupmind.mjs
+++ b/src/adapters/groupmind.mjs
@@ -3,6 +3,7 @@
 import { execFileSync } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
 import { resolveSelfHandle, isSelfSender } from '../common/handles.mjs';
+import { replyIdOf, embeddedTargetOf, resolveReplyTargets, replyAnnotation } from '../common/reply-context.mjs';
 
 /**
  * GroupMind adapter — polls GroupMind rooms for new messages.
@@ -31,14 +32,8 @@ export const groupmindAdapter = {
         // reply_to id survives but means nothing to a reader of the line.
         // (Aug 27 2026: petrus's "spec this" reply was interpreted by guess
         // because every agent-facing surface dropped the reply target.)
-        const byId = new Map(msgs.map((m) => [m.id, m]));
-        for (const m of msgs) {
-          m._room = room;
-          if (m.reply_to && byId.has(m.reply_to)) {
-            const t = byId.get(m.reply_to);
-            m._replyTarget = { from: t.from || t.sender || '?', body: (t.body || '').slice(0, 120) };
-          }
-        }
+        resolveReplyTargets(msgs);
+        for (const m of msgs) m._room = room;
         all.push(...msgs);
       } catch (e) {
         console.error(`  groupmind fetch ${room} failed: ${e.message}`);
@@ -75,8 +70,10 @@ export const groupmindAdapter = {
         body,
         room,
         // A reply's meaning lives in its target - carry it, never drop it.
-        reply_to: msg.reply_to || null,
-        reply_target: msg._replyTarget || null
+        // Shape-normalised here too, not only in fetch(): normalize() must
+        // stay correct for callers that hand it a raw message directly.
+        reply_to: replyIdOf(msg.reply_to),
+        reply_target: msg._replyTarget || embeddedTargetOf(msg.reply_to)
       }
     };
   },
@@ -87,16 +84,8 @@ export const groupmindAdapter = {
     const room = event.room || '';
     const body = (event.payload?.body || '').replace(/\n/g, ' ').slice(0, 200);
     const line = `[${ts}] [${room}] ${sender}: ${body}`;
-    const t = event.payload?.reply_target;
-    if (t) {
-      const snippet = (t.body || '').replace(/\n/g, ' ').slice(0, 100);
-      return `${line}\n    ⤷ in reply to ${t.from}: "${snippet}"`;
-    }
-    if (event.payload?.reply_to) {
-      // Target not in the fetch window - still say it IS a reply so nobody
-      // interprets it as a freestanding statement.
-      return `${line}\n    ⤷ a reply (target ${event.payload.reply_to} not in recent window)`;
-    }
-    return line;
+    // Single physical line - the notification-file contract is one entry per
+    // line (room_ack counts lines; codexmb reproduced overcounting on #70).
+    return line + replyAnnotation(event.payload?.reply_to, event.payload?.reply_target);
   }
 };

--- a/src/common/reply-context.mjs
+++ b/src/common/reply-context.mjs
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+ * Reply-context helpers shared by every GroupMind message reader.
+ *
+ * A reply's meaning lives in its target (27 Aug 2026: "spec this" was
+ * interpreted by guess because every agent-facing surface dropped reply_to).
+ * Both pollers (unified adapter and the legacy team-relay room-poller) must
+ * resolve and render reply context the SAME way, from this module, so the
+ * two paths cannot drift apart.
+ */
+
+/**
+ * reply_to is POLYMORPHIC: the server stores whatever the client POSTed -
+ * a string id, or a rich { id, from, body } object (antfarm route.ts:412;
+ * both shapes seen live 27 Aug 2026). Normalise before any use.
+ */
+export function replyIdOf(raw) {
+  if (typeof raw === 'string' && raw) return raw;
+  if (raw && typeof raw === 'object' && raw.id != null) return String(raw.id);
+  return null;
+}
+
+/** The object form self-carries the target it points at. */
+export function embeddedTargetOf(raw) {
+  if (raw && typeof raw === 'object' && (raw.from || raw.body)) {
+    return { from: raw.from || '?', body: (raw.body || '').slice(0, 120) };
+  }
+  return null;
+}
+
+/**
+ * Resolve reply targets for a fetched batch: a fresh reply's target is
+ * almost always within the same poll window. Falls back to the embedded
+ * object form when the target is older than the window. Sets m._replyToId
+ * and m._replyTarget in place; returns the batch for chaining.
+ */
+export function resolveReplyTargets(msgs) {
+  const byId = new Map(msgs.map((m) => [m.id, m]));
+  for (const m of msgs) {
+    const replyId = replyIdOf(m.reply_to);
+    if (replyId) m._replyToId = replyId;
+    if (replyId && byId.has(replyId)) {
+      const t = byId.get(replyId);
+      m._replyTarget = { from: t.from || t.sender || '?', body: (t.body || '').slice(0, 120) };
+    } else {
+      const embedded = embeddedTargetOf(m.reply_to);
+      if (embedded) m._replyTarget = embedded;
+    }
+  }
+  return msgs;
+}
+
+/**
+ * Inline, SINGLE-LINE annotation suffix ('' for non-replies).
+ *
+ * Single-line on purpose: the notification-file contract is one entry per
+ * physical line (readers split on \n and room_ack counts lines), so a
+ * two-line entry gets delivered as two detached entries and overcounted -
+ * reproduced by codexmb on PR #70. An unresolved reply still says it IS a
+ * reply, so nobody interprets it as a freestanding statement.
+ */
+export function replyAnnotation(replyToId, replyTarget) {
+  if (replyTarget) {
+    const from = replyTarget.from || '?';
+    const snippet = (replyTarget.body || '').replace(/\n/g, ' ').slice(0, 100);
+    return ` ⤷ in reply to ${from}: "${snippet}"`;
+  }
+  if (replyToId) {
+    return ` ⤷ a reply (target ${replyToId} not in recent window)`;
+  }
+  return '';
+}

--- a/src/team-relay/room-poller.mjs
+++ b/src/team-relay/room-poller.mjs
@@ -8,6 +8,7 @@ import { randomUUID } from 'node:crypto';
 import { nudgeCommand } from '../utils.mjs';
 import { shouldSuppressNudge } from '../intent.mjs';
 import { resolveSelfHandle } from '../common/handles.mjs';
+import { resolveReplyTargets, replyAnnotation } from '../common/reply-context.mjs';
 
 /**
  * Room Poller — polls GroupMind rooms and notifies IDE agent of new messages.
@@ -254,6 +255,7 @@ export async function startRoomPoller({ rooms, apiKey, handle, interval, config,
     const newMessages = [];
     for (const room of rooms) {
       const msgs = await fetchRoomMessages(room, apiKey);
+      resolveReplyTargets(msgs);
       for (const m of msgs) {
         const mid = m.id;
         if (!mid || seen.has(mid)) continue;
@@ -278,7 +280,12 @@ export async function startRoomPoller({ rooms, apiKey, handle, interval, config,
           timestamp: ts,
           room,
           actor: { login: sender },
-          payload: { body, room },
+          payload: {
+            body,
+            room,
+            reply_to: m._replyToId || null,
+            reply_target: m._replyTarget || null
+          },
           intent: null,
           memory_context: null,
           enrichment_errors: []
@@ -287,7 +294,8 @@ export async function startRoomPoller({ rooms, apiKey, handle, interval, config,
         appendFileSync(queuePath, JSON.stringify(event) + '\n');
 
         // Collect for notification file
-        const line = `[${ts.slice(0, 19)}] [${room}] ${sender}: ${body.replace(/\n/g, ' ').slice(0, 200)}`;
+        const line = `[${ts.slice(0, 19)}] [${room}] ${sender}: ${body.replace(/\n/g, ' ').slice(0, 200)}`
+          + replyAnnotation(m._replyToId, m._replyTarget);
         newMessages.push(line);
         newCount++;
 

--- a/test/reply-context.test.mjs
+++ b/test/reply-context.test.mjs
@@ -9,6 +9,7 @@ describe('reply-context (shared by both pollers)', () => {
     assert.equal(replyIdOf('abc'), 'abc');
     assert.equal(replyIdOf({ id: 'abc', from: 'x' }), 'abc');
     assert.equal(replyIdOf({ id: 123 }), '123');
+    assert.equal(typeof replyIdOf({ id: 123 }), 'string');
     assert.equal(replyIdOf(null), null);
     assert.equal(replyIdOf(undefined), null);
     assert.equal(replyIdOf(''), null);

--- a/test/reply-context.test.mjs
+++ b/test/reply-context.test.mjs
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { replyIdOf, embeddedTargetOf, resolveReplyTargets, replyAnnotation } from '../src/common/reply-context.mjs';
+
+describe('reply-context (shared by both pollers)', () => {
+  it('replyIdOf handles string, object, and absent forms', () => {
+    assert.equal(replyIdOf('abc'), 'abc');
+    assert.equal(replyIdOf({ id: 'abc', from: 'x' }), 'abc');
+    assert.equal(replyIdOf({ id: 123 }), '123');
+    assert.equal(replyIdOf(null), null);
+    assert.equal(replyIdOf(undefined), null);
+    assert.equal(replyIdOf(''), null);
+    assert.equal(replyIdOf({}), null);
+  });
+
+  it('embeddedTargetOf extracts from the rich object form only', () => {
+    assert.deepEqual(embeddedTargetOf({ id: 'a', from: '@x', body: 'hello' }), { from: '@x', body: 'hello' });
+    assert.equal(embeddedTargetOf('a'), null);
+    assert.equal(embeddedTargetOf({ id: 'a' }), null);
+  });
+
+  it('resolveReplyTargets resolves in-batch targets', () => {
+    const msgs = [
+      { id: 'aaa', from: '@claudeMB', body: 'the fleet message' },
+      { id: 'bbb', from: 'petrus', body: 'spec this', reply_to: 'aaa' }
+    ];
+    resolveReplyTargets(msgs);
+    assert.equal(msgs[1]._replyToId, 'aaa');
+    assert.equal(msgs[1]._replyTarget.from, '@claudeMB');
+  });
+
+  it('resolveReplyTargets falls back to the embedded object outside the window', () => {
+    const msgs = [
+      { id: 'bbb', from: 'petrus', body: 'spec this', reply_to: { id: 'old1', from: '@claudeMB', body: 'ancient message' } }
+    ];
+    resolveReplyTargets(msgs);
+    assert.equal(msgs[0]._replyToId, 'old1');
+    assert.equal(msgs[0]._replyTarget.body, 'ancient message');
+  });
+
+  it('replyAnnotation is single-line and empty for non-replies', () => {
+    assert.equal(replyAnnotation(null, null), '');
+    const resolved = replyAnnotation('aaa', { from: '@x', body: 'multi\nline\nbody' });
+    assert.ok(resolved.includes('in reply to @x'));
+    assert.ok(!resolved.includes('\n'), resolved);
+    const unresolved = replyAnnotation('aaa', null);
+    assert.ok(unresolved.includes('aaa'));
+    assert.ok(!unresolved.includes('\n'), unresolved);
+  });
+});

--- a/test/unified-poller.test.mjs
+++ b/test/unified-poller.test.mjs
@@ -177,6 +177,9 @@ describe('groupmind reply targets', () => {
   it('handles the OBJECT form of reply_to (server stores what clients POST)', () => {
     const objReply = { ...reply, reply_to: { id: 'aaa', from: '@claudeMB', body: 'the AgentOS fleet message' } };
     const ev = groupmindAdapter.normalize(objReply, { poller: { handle: '@test' } });
+    // Ported from #71 (claudemm): object-form input must yield the id as a
+    // STRING, so no consumer ever branches on the wire format.
+    assert.equal(typeof ev.payload.reply_to, 'string');
     assert.equal(ev.payload.reply_to, 'aaa');
     assert.equal(ev.payload.reply_target.from, '@claudeMB');
     const line = groupmindAdapter.formatLine(ev);

--- a/test/unified-poller.test.mjs
+++ b/test/unified-poller.test.mjs
@@ -155,23 +155,37 @@ describe('groupmind reply targets', () => {
     assert.equal(ev.payload.reply_target.from, '@claudeMB');
   });
 
-  it('formatLine shows the resolved reply target', () => {
+  it('formatLine shows the resolved reply target on ONE physical line', () => {
     const withTarget = { ...reply, _replyTarget: { from: target.from, body: target.body } };
     const ev = groupmindAdapter.normalize(withTarget, { poller: { handle: '@test' } });
     const line = groupmindAdapter.formatLine(ev);
     assert.ok(line.includes('in reply to @claudeMB'), line);
     assert.ok(line.includes('the AgentOS fleet message'), line);
+    // Notification-file contract: one entry per physical line (room_ack
+    // counts lines; two-line entries were delivered as detached entries).
+    assert.ok(!line.includes('\n'), 'must be single-line: ' + line);
   });
 
   it('formatLine marks an unresolved reply as a reply, never freestanding', () => {
     const ev = groupmindAdapter.normalize(reply, { poller: { handle: '@test' } });
     const line = groupmindAdapter.formatLine(ev);
     assert.ok(line.includes('a reply'), line);
-    assert.ok(line.includes('bbb') === false, 'target id, not own id');
     assert.ok(line.includes('aaa'), line);
+    assert.ok(!line.includes('\n'), 'must be single-line: ' + line);
   });
 
-  it('non-replies keep the plain single-line format', () => {
+  it('handles the OBJECT form of reply_to (server stores what clients POST)', () => {
+    const objReply = { ...reply, reply_to: { id: 'aaa', from: '@claudeMB', body: 'the AgentOS fleet message' } };
+    const ev = groupmindAdapter.normalize(objReply, { poller: { handle: '@test' } });
+    assert.equal(ev.payload.reply_to, 'aaa');
+    assert.equal(ev.payload.reply_target.from, '@claudeMB');
+    const line = groupmindAdapter.formatLine(ev);
+    assert.ok(line.includes('in reply to @claudeMB'), line);
+    assert.ok(!line.includes('[object Object]'), line);
+    assert.ok(!line.includes('\n'), 'must be single-line: ' + line);
+  });
+
+  it('non-replies keep the plain format with no annotation', () => {
     const ev = groupmindAdapter.normalize(target, { poller: { handle: '@test' } });
     const line = groupmindAdapter.formatLine(ev);
     assert.ok(!line.includes('reply'), line);


### PR DESCRIPTION
Follow-up to #70, which merged before its review findings were addressed. Fixes all three:

1. **reply_to polymorphism** (@claudemm's finding): the field is a string id OR a rich `{id, from, body}` object (server stores what clients POST, antfarm route.ts:412). Both shapes handled; the object form self-carries its target, so a reply to a message older than the poll window still renders who/what it answered instead of `[object Object]`.

2. **Notification-file contract** (@codexmb's finding, reproduced): readers split on newlines and room_ack counts lines, so the two-line annotation was delivered as detached entries and overcounted. The annotation is now inline on the SAME physical line.

3. **Legacy `rooms watch` path** (@codexmb's finding): `src/team-relay/room-poller.mjs` now resolves and renders reply context via the same shared module (`src/common/reply-context.mjs`), so the two paths cannot drift apart.

Tests: object-form, single-line contract, and shared-module units. Suite 263/263.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
