### PR TITLE
surface attachments in both poller paths (lost-screenshot lesson)

### DIFF
--- a/src/adapters/groupmind.mjs
+++ b/src/adapters/groupmind.mjs
@@ -54,7 +54,13 @@ export const groupmindAdapter = {
 
   normalize(msg, config) {
     const sender = msg.from || msg.sender || '?';
-    const body = (msg.body || '').slice(0, 500);
+    let body = (msg.body || '').slice(0, 500);
+    // Surface every attachment kind. 2026-07-19: petrus posted a screenshot
+    // that never reached the agent (bodies-only extraction) and got asked to
+    // re-post it - an attachment must never be invisible.
+    if (msg.image_url) body += ` [IMAGE ATTACHED: ${msg.image_url}]`;
+    if (msg.audio_url) body += ` [AUDIO ATTACHED: ${msg.audio_url}]`;
+    if (msg.file_url) body += ` [FILE ATTACHED: ${msg.file_name || msg.file_url}]`;
     const ts = msg.created_at || new Date().toISOString();
     const room = msg._room || '';
 

--- a/src/team-relay/room-poller.mjs
+++ b/src/team-relay/room-poller.mjs
@@ -268,7 +268,12 @@ export async function startRoomPoller({ rooms, apiKey, handle, interval, config,
         if (normalizedSender === ownerHandle) hasOwnerMessage = true;
         if ((m.body || '').toLowerCase().includes(mentionNeedle)) hasMention = true;
 
-        const body = (m.body || '').slice(0, 500);
+        let body = (m.body || '').slice(0, 500);
+        // Surface attachments (2026-07-19 lost-screenshot lesson): an
+        // image/audio/file must never be invisible to the agent.
+        if (m.image_url) body += ` [IMAGE ATTACHED: ${m.image_url}]`;
+        if (m.audio_url) body += ` [AUDIO ATTACHED: ${m.audio_url}]`;
+        if (m.file_url) body += ` [FILE ATTACHED: ${m.file_name || m.file_url}]`;
         const ts = m.created_at || new Date().toISOString();
 
         // Write to structured queue

--- a/test/unified-poller.test.mjs
+++ b/test/unified-poller.test.mjs
@@ -195,3 +195,20 @@ describe('groupmind reply targets', () => {
     assert.ok(!line.includes('\n'), line);
   });
 });
+
+describe('groupmind attachment surfacing', () => {
+  // 2026-07-19: a posted screenshot never reached the agent (bodies-only
+  // extraction) and petrus was asked to re-post it. Never again.
+  it('normalize appends image/audio/file labels to the body', () => {
+    const base = { id: 'x', from: 'petrus', created_at: '2026-08-27T09:00:00Z', _room: 'r' };
+    const cfg = { poller: { handle: '@test' } };
+    const img = groupmindAdapter.normalize({ ...base, body: 'look', image_url: 'https://x/i.jpg' }, cfg);
+    assert.ok(img.payload.body.includes('[IMAGE ATTACHED: https://x/i.jpg]'), img.payload.body);
+    const aud = groupmindAdapter.normalize({ ...base, body: 'listen', audio_url: 'https://x/a.ogg' }, cfg);
+    assert.ok(aud.payload.body.includes('[AUDIO ATTACHED: https://x/a.ogg]'), aud.payload.body);
+    const fil = groupmindAdapter.normalize({ ...base, body: 'take', file_url: 'https://x/f.bin', file_name: 'f.bin' }, cfg);
+    assert.ok(fil.payload.body.includes('[FILE ATTACHED: f.bin]'), fil.payload.body);
+    const plain = groupmindAdapter.normalize({ ...base, body: 'no extras' }, cfg);
+    assert.ok(!plain.payload.body.includes('ATTACHED'), plain.payload.body);
+  });
+});


### PR DESCRIPTION
Step 2 of "no custom hack pollers": fold the MacBook bespoke script's features into the product.

This PR ports **attachment surfacing** — the 2026-07-19 lesson (a posted screenshot was invisible to a bodies-only extraction and petrus was asked to re-post it). Both message paths now append `[IMAGE/AUDIO/FILE ATTACHED: ...]` to the body:

- canonical `src/adapters/groupmind.mjs` `normalize()` (unified poller)
- legacy `src/team-relay/room-poller.mjs` body build (`rooms watch`)

Tests for all three kinds + the no-attachment case. Suite 278/278.

Remaining parity items tracked for follow-ups: wake-on-mention hook, 401/403 key hot-reload (legacy `rooms watch` already has DM polling + command nudge via `dm_poller` / `nudge_mode` config).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
