### PR TITLE
security(confirmations): exact-name owner allowlist for intent settling

### DIFF
--- a/bin/iak-mcp-daemon.mjs
+++ b/bin/iak-mcp-daemon.mjs
@@ -86,6 +86,11 @@ if (!apiKey) {
 } else {
   startChatReplyPoller({
     apiKey, room, intervalMs: 5000,
+    // Exact owner identities allowed to settle intents (config, with the
+    // fleet's known surfaces as the default). Every surface the owner taps
+    // from must be listed — an unlisted one gets a VISIBLE rejection reply,
+    // never silence.
+    owners: config?.mcp?.confirmations?.owners || ['petrus', 'petrus-boox'],
     log: (msg) => console.log(`[iak-mcp-daemon] ${msg}`),
   });
   console.log(`[iak-mcp-daemon] chat-reply poller watching room "${room}" every 5s`);

--- a/src/confirmations.mjs
+++ b/src/confirmations.mjs
@@ -1140,13 +1140,14 @@ export function startChatReplyPoller({ apiKey, room, intervalMs = 5000, log, own
         // gated command. Agent senders carry a handle ("@ether", "hermes");
         // the owner posts as plain "petrus" (CodeWatch button taps included).
         const sender = String(m.from || '').replace(/^@/, '').toLowerCase();
-        // Authorization: exact membership in the owners set. The isHuman path
-        // stays (codexmb 2026-08-27: it is SERVER-derived — set only when the
-        // caller authenticated as a session user, never mintable via an agent
-        // key). Residual, accepted knowingly: any human MEMBER of the room
-        // could settle. Today the owner is the only human in the room; if that
-        // changes, intersect this with ownerSet.
-        if (!ownerSet.has(sender) && m.isHuman !== true) {
+        // Authorization: exact membership in the owners set, nothing else.
+        // isHuman is server-derived and cannot be minted via an agent key,
+        // but it only proves the sender is A human, not THE owner — any other
+        // human member of the room would have inherited settle authority
+        // through it (codexmb's merge-blocking finding on this PR). A human
+        // whose tap is refused is told so visibly below; adding their handle
+        // to owners is the fix, silence never is.
+        if (!ownerSet.has(sender)) {
           emit(`${text} from ${m.from}: sender is not the owner — ignoring`);
           // Answer only senders who plausibly ARE the owner (`petrus`,
           // `petrus-boox`, a future `petrus-watch`). claudeMB's review caught
@@ -1163,7 +1164,11 @@ export function startChatReplyPoller({ apiKey, room, intervalMs = 5000, log, own
           // the right answer for it.
           // "Plausibly the owner" for reply purposes only — NEVER for
           // authorization: prefix-matching authority is the petrus-helper hole.
-          const ownerish = [...ownerSet].some((o) => sender === o || sender.startsWith(`${o}-`));
+          // Reply visibly to anyone who might actually be at a screen: a
+          // sender that RESEMBLES an owner surface, or any server-verified
+          // human. Agents emitting spurious /approve get the log line only.
+          const ownerish = m.isHuman === true
+            || [...ownerSet].some((o) => sender === o || sender.startsWith(`${o}-`));
           if (ownerish) {
             await reply(
               `\`${text}\` was NOT recorded — the intent is still pending. ` +

--- a/src/confirmations.mjs
+++ b/src/confirmations.mjs
@@ -1085,7 +1085,10 @@ export function startChatReplyPoller({ apiKey, room, intervalMs = 5000, log, own
     return null;
   }
   const ownerSet = new Set(
-    (Array.isArray(owners) && owners.length ? owners : [owner])
+    // An array — INCLUDING an explicitly empty one — is authoritative: [] is
+    // the lockdown config where nobody settles from chat. Only an absent /
+    // non-array value falls back to the legacy single `owner`.
+    (Array.isArray(owners) ? owners : [owner])
       .map((o) => String(o).replace(/^@/, '').toLowerCase())
   );
   const emit = log || ((msg) => process.stderr.write(`[iak-mcp] ${msg}\n`));

--- a/src/confirmations.mjs
+++ b/src/confirmations.mjs
@@ -1068,13 +1068,26 @@ export function composeAnnouncers(map) {
 // `owner` is the account handle decisions are accepted from. It also decides
 // who is worth ANSWERING when a decision is rejected: see `ownerish` below.
 // Defaulting it keeps existing callers behaving identically, but it is a
-// parameter rather than a literal because this ships as a product and the
-// owner is not always called petrus.
-export function startChatReplyPoller({ apiKey, room, intervalMs = 5000, log, owner = 'petrus' }) {
+// `owners` is an EXPLICIT list of exact handles allowed to settle intents,
+// deliberately not a prefix match: an agent can register any handle it likes,
+// so `petrus-*` would let a fleet agent call itself "petrus-helper" and inherit
+// approval authority — the precise attack this guard exists to stop. A list
+// rather than one name because a person is not one handle: they are a laptop,
+// a tablet and a watch (2026-08-03: a decision from the owner's own tablet,
+// "@petrus-boox", was dropped in silence because this compared against the
+// literal "petrus" — he tapped Approve on camera and nothing happened).
+// Ported from the Mini's field-hardened fork (branch mini-local-fork-rescue),
+// security-reviewed by codexmb 2026-08-27; `owner` kept as an alias so
+// existing call sites keep working.
+export function startChatReplyPoller({ apiKey, room, intervalMs = 5000, log, owners, owner = 'petrus' }) {
   if (!apiKey || !room) {
     process.stderr.write('[iak-mcp] chat-reply poller: missing apiKey or room — disabled\n');
     return null;
   }
+  const ownerSet = new Set(
+    (Array.isArray(owners) && owners.length ? owners : [owner])
+      .map((o) => String(o).replace(/^@/, '').toLowerCase())
+  );
   const emit = log || ((msg) => process.stderr.write(`[iak-mcp] ${msg}\n`));
   const seen = new Set();
   let primed = false;
@@ -1127,7 +1140,13 @@ export function startChatReplyPoller({ apiKey, room, intervalMs = 5000, log, own
         // gated command. Agent senders carry a handle ("@ether", "hermes");
         // the owner posts as plain "petrus" (CodeWatch button taps included).
         const sender = String(m.from || '').replace(/^@/, '').toLowerCase();
-        if (sender !== 'petrus' && m.isHuman !== true) {
+        // Authorization: exact membership in the owners set. The isHuman path
+        // stays (codexmb 2026-08-27: it is SERVER-derived — set only when the
+        // caller authenticated as a session user, never mintable via an agent
+        // key). Residual, accepted knowingly: any human MEMBER of the room
+        // could settle. Today the owner is the only human in the room; if that
+        // changes, intersect this with ownerSet.
+        if (!ownerSet.has(sender) && m.isHuman !== true) {
           emit(`${text} from ${m.from}: sender is not the owner — ignoring`);
           // Answer only senders who plausibly ARE the owner (`petrus`,
           // `petrus-boox`, a future `petrus-watch`). claudeMB's review caught
@@ -1142,7 +1161,9 @@ export function startChatReplyPoller({ apiKey, room, intervalMs = 5000, log, own
           // A human who tapped Approve needs to know it did not land. An agent
           // emitting a spurious `/approve` does not; the log line was always
           // the right answer for it.
-          const ownerish = sender === owner || sender.startsWith(`${owner}-`);
+          // "Plausibly the owner" for reply purposes only — NEVER for
+          // authorization: prefix-matching authority is the petrus-helper hole.
+          const ownerish = [...ownerSet].some((o) => sender === o || sender.startsWith(`${o}-`));
           if (ownerish) {
             await reply(
               `\`${text}\` was NOT recorded — the intent is still pending. ` +

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -461,7 +461,11 @@ export async function runMcpServer({ configPath } = {}) {
     // never settles the intent. Only start when this process holds the intents
     // (groupmind channel configured + serving in-process, not forwarding).
     if (announcerMap.groupmind) {
-      startChatReplyPoller({ apiKey: config.poller.api_key, room: confirmCfg.room });
+      startChatReplyPoller({
+        apiKey: config.poller.api_key,
+        room: confirmCfg.room,
+        owners: confirmCfg.owners || ['petrus', 'petrus-boox'],
+      });
       process.stderr.write(
         `[iak-mcp] chat-reply poller: watching room "${confirmCfg.room}" every 5s\n`
       );

--- a/test/confirmations.test.mjs
+++ b/test/confirmations.test.mjs
@@ -9,6 +9,7 @@ import {
   waitForDecision,
   listIntents,
   startConfirmationsServer,
+  startChatReplyPoller,
   composeAnnouncers,
   _resetForTests,
 } from '../src/confirmations.mjs';
@@ -196,4 +197,92 @@ test('HTTP auth gate rejects missing/wrong bearer token when configured', async 
   } finally {
     srv.close();
   }
+});
+
+
+// --- owner allowlist (ported from the Mini fork, reviewed by codexmb) --------
+//
+// The guard decides WHOSE approvals count, so it is tested behaviourally:
+// mocked room fetches drive the real poll loop and we watch which senders
+// get to settle a real intent.
+
+test('chat-reply poller: exact owners settle, lookalikes and agents do not', async () => {
+  _resetForTests();
+  const shortId = await createIntent({ prompt: 'test intent', announce: async () => {} });
+
+  const batches = [
+    { messages: [] }, // priming pass
+    { messages: [
+      // an agent that named itself to LOOK like an owner: must be rejected
+      { id: 'm1', from: '@petrus-helper', body: `/approve ${shortId}`, isHuman: false },
+      // a genuine configured owner surface: must settle
+      { id: 'm2', from: '@petrus-boox', body: `/approve ${shortId}`, isHuman: false },
+    ] },
+  ];
+  let call = 0;
+  const posts = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (url, opts) => {
+    if (opts && opts.method === 'POST') { posts.push(JSON.parse(opts.body)); return { ok: true, json: async () => ({}) }; }
+    const batch = batches[Math.min(call++, batches.length - 1)];
+    return { ok: true, json: async () => batch };
+  };
+  const lines = [];
+  const handle = startChatReplyPoller({
+    apiKey: 'k', room: 'r', intervalMs: 10,
+    owners: ['petrus', 'petrus-boox'],
+    log: (m) => lines.push(m),
+  });
+  try {
+    await new Promise((r) => setTimeout(r, 120));
+  } finally {
+    clearInterval(handle);
+    globalThis.fetch = originalFetch;
+  }
+
+  const joined = lines.join('\n');
+  // the lookalike was refused BEFORE any settle attempt
+  assert.match(joined, /petrus-helper.*not the owner/i);
+  // the real owner surface settled the intent
+  const settled = listIntents().find((i) => i.id === shortId);
+  assert.equal(settled.status, 'decided');
+  assert.equal(settled.decision, 'approve');
+  // and the lookalike got NO settle: decision came from the m2 pass only
+  assert.match(joined, new RegExp(`/approve ${shortId} from @petrus-boox: settled`));
+});
+
+test('chat-reply poller: prefix similarity earns a visible reply, never authority', async () => {
+  _resetForTests();
+  const intentId = await createIntent({ prompt: 'second intent', announce: async () => {} });
+  const batches = [
+    { messages: [] },
+    { messages: [
+      { id: 'p1', from: '@petrus-watch2', body: `/approve ${intentId}`, isHuman: false },
+    ] },
+  ];
+  let call = 0;
+  const posts = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (url, opts) => {
+    if (opts && opts.method === 'POST') { posts.push(JSON.parse(opts.body)); return { ok: true, json: async () => ({}) }; }
+    const batch = batches[Math.min(call++, batches.length - 1)];
+    return { ok: true, json: async () => batch };
+  };
+  const handle = startChatReplyPoller({
+    apiKey: 'k', room: 'r', intervalMs: 10,
+    owners: ['petrus'],
+    log: () => {},
+  });
+  try {
+    await new Promise((r) => setTimeout(r, 120));
+  } finally {
+    clearInterval(handle);
+    globalThis.fetch = originalFetch;
+  }
+  // still pending: the prefix lookalike had no authority
+  const still = listIntents().find((i) => i.id === intentId);
+  assert.equal(still.status, 'pending');
+  // but because it LOOKS like an owner surface, a visible rejection was posted
+  assert.equal(posts.length, 1);
+  assert.match(posts[0].body, /NOT recorded/);
 });

--- a/test/confirmations.test.mjs
+++ b/test/confirmations.test.mjs
@@ -324,3 +324,41 @@ test('chat-reply poller: a human who is not a listed owner cannot settle, and is
   assert.equal(posts.length, 1, 'and must be told visibly');
   assert.match(posts[0].body, /NOT recorded/);
 });
+
+test('chat-reply poller: an explicitly empty owners list is lockdown — even the legacy owner cannot settle', async () => {
+  // codexmb's follow-up finding on #76: `owners.length ? owners : [owner]`
+  // silently replaced a deliberate [] (nobody settles from chat) with the
+  // legacy petrus fallback. An empty array must be authoritative.
+  _resetForTests();
+  const intentId = await createIntent({ prompt: 'locked', announce: async () => {} });
+  const batches = [
+    { messages: [] },
+    { messages: [
+      { id: 'l1', from: 'petrus', body: `/approve ${intentId}`, isHuman: true },
+    ] },
+  ];
+  let call = 0;
+  const posts = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (url, opts) => {
+    if (opts && opts.method === 'POST') { posts.push(JSON.parse(opts.body)); return { ok: true, json: async () => ({}) }; }
+    const batch = batches[Math.min(call++, batches.length - 1)];
+    return { ok: true, json: async () => batch };
+  };
+  const handle = startChatReplyPoller({
+    apiKey: 'k', room: 'r', intervalMs: 10,
+    owners: [],
+    log: () => {},
+  });
+  try {
+    await new Promise((r) => setTimeout(r, 120));
+  } finally {
+    clearInterval(handle);
+    globalThis.fetch = originalFetch;
+  }
+  const still = listIntents().find((i) => i.id === intentId);
+  assert.equal(still.status, 'pending', 'lockdown means nobody settles, petrus included');
+  // isHuman sender still gets the visible refusal so the lockdown is discoverable
+  assert.equal(posts.length, 1);
+  assert.match(posts[0].body, /NOT recorded/);
+});

--- a/test/confirmations.test.mjs
+++ b/test/confirmations.test.mjs
@@ -286,3 +286,41 @@ test('chat-reply poller: prefix similarity earns a visible reply, never authorit
   assert.equal(posts.length, 1);
   assert.match(posts[0].body, /NOT recorded/);
 });
+
+
+test('chat-reply poller: a human who is not a listed owner cannot settle, and is told visibly', async () => {
+  // codexmb's merge-blocking finding on #76: isHuman proves A human, not THE
+  // owner. An unlisted human must be refused — and must SEE the refusal,
+  // because a person who tapped Approve and hears nothing assumes it landed.
+  _resetForTests();
+  const intentId = await createIntent({ prompt: 'guarded', announce: async () => {} });
+  const batches = [
+    { messages: [] },
+    { messages: [
+      { id: 'h1', from: 'marina', body: `/approve ${intentId}`, isHuman: true },
+    ] },
+  ];
+  let call = 0;
+  const posts = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (url, opts) => {
+    if (opts && opts.method === 'POST') { posts.push(JSON.parse(opts.body)); return { ok: true, json: async () => ({}) }; }
+    const batch = batches[Math.min(call++, batches.length - 1)];
+    return { ok: true, json: async () => batch };
+  };
+  const handle = startChatReplyPoller({
+    apiKey: 'k', room: 'r', intervalMs: 10,
+    owners: ['petrus'],
+    log: () => {},
+  });
+  try {
+    await new Promise((r) => setTimeout(r, 120));
+  } finally {
+    clearInterval(handle);
+    globalThis.fetch = originalFetch;
+  }
+  const still = listIntents().find((i) => i.id === intentId);
+  assert.equal(still.status, 'pending', 'unlisted human must not settle');
+  assert.equal(posts.length, 1, 'and must be told visibly');
+  assert.match(posts[0].body, /NOT recorded/);
+});


### PR DESCRIPTION
Ports the Mini fork's approval guard into main — THI-27, reviewed in principle by codexmb (2026-08-27) before this PR existed; requesting his adversarial pass on the actual diff now.

**What changes**
- Authorization = exact membership in a normalised `owners` set. Never prefix-matched: `petrus-helper` must not inherit authority (that attack is why the guard exists).
- Main's visible-rejection UX kept and generalised to the owners list — similarity earns a reply, never authority.
- `isHuman` path kept (server-derived, not agent-mintable — verified in the antfarm routes); its accepted residual (any human room MEMBER could settle; the owner is currently the only human) documented at the check.
- Both call sites (`iak-mcp-daemon`, `mcp-server`) wire owners explicitly, default `['petrus','petrus-boox']`, configurable via `mcp.confirmations.owners`. Backwards-compatible: `owner` singular still works.

**Tests**: behavioural, driving the real poll loop with mocked fetches — lookalike refused, real surface settles, prefix-lookalike gets the visible reply while the intent stays pending. Suite 17/17.

**After merge**: the Mini updates to main and its stale daemon finally restarts (THI-27) — closing the CVE-2026-13676 deployment gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)