### PR TITLE
Stop telling the owner an approval failed when another poller settled it

### DIFF
--- a/scripts/claudemm-uik-daemon.sh
+++ b/scripts/claudemm-uik-daemon.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# claudemm presence publisher (Mac mini). Reads the API key from the canonical
+# config at start so key rotations self-heal — never hardcode keys here
+# (the old xfb_63eddeba… key was hardcoded in publishers and silently 401'd
+# for a day after the 2026-07-03 rotation).
+set -euo pipefail
+IAK_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+CONFIG="$IAK_DIR/config/dogfood.json"
+
+export INTENT_API_BASE="$(python3 -c "import json;print(json.load(open('$CONFIG'))['intent']['baseUrl'])")"
+export INTENT_API_KEY="$(python3 -c "import json;print(json.load(open('$CONFIG'))['intent']['apiKey'])")"
+export INTENT_USER_ID="claudemm"
+export INTENT_AGENT_HANDLE="@claudemm"
+export INTENT_DEVICE_ID="mac-mini"
+
+exec node "$IAK_DIR/packages/user-intent-kit/bin/uik-daemon.js"

--- a/scripts/mini-vitals.sh
+++ b/scripts/mini-vitals.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# Republish the Mac mini's host facts into its intent device slot.
+#
+# The DesktopAdapter publishes a thin slot on macOS (load_pct, mem_available_gb,
+# idle_sec, active_app). The Pi's row shows model/temp/load/memory, so the Mini
+# looked empty next to it in CodeWatch's Local devices (petrus 2026-08-19:
+# "we need your stats in the table too").
+#
+# Static facts could be patched once, but load and free memory cannot: a value
+# patched once freezes while the row still says "now", which is worse than an
+# absent field. So this refreshes on the daemon's own cadence.
+#
+# temp_c and watts_w are deliberately NOT published: reading them on macOS needs
+# root, and the fleet contract is that an unreadable sensor is omitted, never zeroed.
+set -u
+IAK_DIR="/Users/petrus/ide-agent-kit"
+NODE="/opt/homebrew/bin/node"
+CONFIG="$IAK_DIR/config/dogfood.json"
+cd "$IAK_DIR"
+while true; do
+  LOAD1=$(sysctl -n vm.loadavg | awk '{print $2}')
+  NCPU=$(sysctl -n hw.ncpu)
+  read -r MEMT MEMA <<< "$(python3 -c "
+import subprocess,re
+total=int(subprocess.check_output(['sysctl','-n','hw.memsize']))/1e9
+o=subprocess.check_output(['vm_stat']).decode()
+ps=int(re.search(r'page size of (\d+)',o).group(1))
+g=lambda k:int(re.search(k+r':\s+(\d+)',o).group(1))
+avail=(g('Pages free')+g('Pages inactive')+g('Pages speculative'))*ps/1e9
+print(f'{total:.1f} {avail:.1f}')")"
+  $NODE bin/cli.mjs intent patch \
+    kind=mac-mini cpu_count="$NCPU" load_1m="$LOAD1" \
+    mem_total_gb="$MEMT" mem_available_gb="$MEMA" \
+    memory="${MEMT}GB total, ${MEMA}GB available" \
+    --config "$CONFIG" >/dev/null 2>&1 || true
+  sleep 30
+done

--- a/src/confirmations.mjs
+++ b/src/confirmations.mjs
@@ -1186,11 +1186,25 @@ export function startChatReplyPoller({ apiKey, room, intervalMs = 5000, log, own
         const id = match[2];
         const intent = getIntent(id);
         if (!intent) {
-          emit(`/${decision} ${id} from ${m.from}: unknown intent, ignoring`);
-          await reply(
-            `\`/${decision} ${id}\` was NOT recorded — no intent with that id. ` +
-            `It has probably expired or been settled already.`
-          );
+          // Log, but do NOT tell the owner it failed. More than one machine
+          // runs this poller against the same room, and each keeps its OWN
+          // intent store, so "unknown to me" does not mean unknown — the
+          // poller that owns the intent settles it while every other poller
+          // sees an id it has never heard of.
+          //
+          // 2026-08-30: petrus tapped Approve on 84967c40 and b69eaa2c. Both
+          // were recorded and settled (decision=approve, seconds after the
+          // tap) by the poller holding them, while a second poller posted
+          // "was NOT recorded — no intent with that id" for each. He re-tapped
+          // b69eaa2c because of that message and was told the same thing
+          // again. A false failure is worse than silence: it makes a working
+          // approval look broken and sends the owner round the loop.
+          //
+          // The genuinely-stale case loses its notice, which is the cheaper
+          // error: nothing happens, and the pending list still shows the
+          // truth. Restore a reply here only once a poller can tell "expired"
+          // apart from "belongs to another poller".
+          emit(`/${decision} ${id} from ${m.from}: unknown intent here, staying silent (another poller may own it)`);
           continue;
         }
         const r = decideIntent(id, decision);

--- a/test/confirmations.test.mjs
+++ b/test/confirmations.test.mjs
@@ -362,3 +362,40 @@ test('chat-reply poller: an explicitly empty owners list is lockdown — even th
   assert.equal(posts.length, 1);
   assert.match(posts[0].body, /NOT recorded/);
 });
+
+test('chat-reply poller: an unknown intent id gets a log line, never a "NOT recorded" reply', async () => {
+  // Two machines run this poller against the same room, each with its own
+  // intent store. The one holding the intent settles it; every other one sees
+  // an id it never created. Replying there tells the owner a working approval
+  // failed — which is exactly what happened to petrus on 2026-08-30, twice,
+  // and made him re-tap an approval that had already been recorded.
+  _resetForTests();
+  const batches = [
+    { messages: [] },
+    { messages: [
+      { id: 'u1', from: 'petrus', body: '/approve deadbeef', isHuman: true },
+    ] },
+  ];
+  let call = 0;
+  const posts = [];
+  const logs = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (url, opts) => {
+    if (opts && opts.method === 'POST') { posts.push(JSON.parse(opts.body)); return { ok: true, json: async () => ({}) }; }
+    const batch = batches[Math.min(call++, batches.length - 1)];
+    return { ok: true, json: async () => batch };
+  };
+  const handle = startChatReplyPoller({
+    apiKey: 'k', room: 'r', intervalMs: 10,
+    owners: ['petrus'],
+    log: (line) => logs.push(String(line)),
+  });
+  try {
+    await new Promise((r) => setTimeout(r, 120));
+  } finally {
+    clearInterval(handle);
+    globalThis.fetch = originalFetch;
+  }
+  assert.equal(posts.length, 0, 'an id this poller does not hold must not be declared missing to the owner');
+  assert.ok(logs.some((l) => /unknown intent here/.test(l)), 'but it must still be logged locally');
+});


### PR DESCRIPTION
**Petrus tapped Approve twice this morning and was told twice that it had not worked. Both times it had.**

`84967c40` — created 11:19:03, decided 11:21:20, `approve`. The approved command ran: `caffeinate -dimsu -t 10800` is PID 42702 on the MacBook right now.
`b69eaa2c` — created 11:22:57, decided 11:23:15, `approve`. He re-tapped it at 11:23:51 *because of the false message*, and got the same reply again.

**Cause:** more than one machine runs `startChatReplyPoller` against the same room, and each keeps its own intent store. The poller holding the intent settles it; every other poller sees an id it never created and posts `was NOT recorded — no intent with that id`. So the machine that did nothing contradicts the machine that did the work.

A false failure is worse than silence here: it makes a working approval look broken and sends the owner round the loop re-tapping settled items.

**Change:** the unknown-id branch logs and stays silent. The genuinely-expired case loses its notice — the cheaper error, since nothing happens and the pending list still shows the truth. A comment records the condition for restoring a reply: when a poller can distinguish 'expired' from 'belongs to another poller'.

**Untouched:** the authorization branch. A human refused because they are not an owner still gets told visibly — that was codexmb's merge-blocking finding on #76 and it still holds.

**Verification:** new test asserts zero posts and one log line for an unheld id. I confirmed it **fails against the unpatched source** and passes with the fix, so it is a real gate rather than a passing assertion. Full suite: 285 pass, 0 fail.

Worth a look from @codexmb.