### PR TITLE
Let the approval queue shrink: /intents?status= filter

### DIFF
--- a/src/confirmations.mjs
+++ b/src/confirmations.mjs
@@ -610,8 +610,31 @@ export function startConfirmationsServer({
       return;
     }
     if (req.method === 'GET' && url.pathname === '/intents') {
+      // ?status=pending narrows the list. Without it the queue returns every
+      // intent ever created, decided ones included, so the phone shows a list
+      // that only grows - petrus re-taps items that settled hours ago because
+      // they are still sitting there looking open. On 2026-08-30 one of those
+      // re-taps was an echo of a migration fix that had already run; executing
+      // it again would have killed a healthy rsync mid-copy.
+      //
+      // Unknown values return an error rather than silently listing everything:
+      // a filter that quietly does nothing is how this went unnoticed.
+      const want = url.searchParams.get('status');
+      let out = listIntents();
+      if (want !== null) {
+        const allowed = new Set(['pending', 'decided']);
+        if (!allowed.has(want)) {
+          res.writeHead(400, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({
+            ok: false,
+            error: `unknown status '${want}' - use one of: ${[...allowed].join(', ')}`,
+          }));
+          return;
+        }
+        out = out.filter((i) => i.status === want);
+      }
       res.writeHead(200, { 'Content-Type': 'application/json' });
-      res.end(JSON.stringify(listIntents()));
+      res.end(JSON.stringify(out));
       return;
     }
     if (req.method === 'POST' && url.pathname === '/actions/request') {

--- a/test/confirmations.test.mjs
+++ b/test/confirmations.test.mjs
@@ -399,3 +399,34 @@ test('chat-reply poller: an unknown intent id gets a log line, never a "NOT reco
   assert.equal(posts.length, 0, 'an id this poller does not hold must not be declared missing to the owner');
   assert.ok(logs.some((l) => /unknown intent here/.test(l)), 'but it must still be logged locally');
 });
+
+test('GET /intents?status=pending returns only open intents, and rejects unknown values', async () => {
+  // The queue used to return every intent ever created regardless of the
+  // status asked for, so petrus's phone showed a list that only grew and he
+  // re-tapped things that had settled hours earlier. On 2026-08-30 one such
+  // re-tap was an echo of a migration fix that had already run - executing it
+  // again would have killed a healthy rsync mid-copy.
+  _resetForTests();
+  const openId = await createIntent({ prompt: 'still open', announce: async () => {} });
+  const doneId = await createIntent({ prompt: 'already settled', announce: async () => {} });
+  decideIntent(doneId, 'approve');
+
+  const server = startConfirmationsServer({ port: 0, host: '127.0.0.1' });
+  await new Promise((r) => server.listening ? r() : server.once('listening', r));
+  const base = `http://127.0.0.1:${server.address().port}`;
+  try {
+    const all = await (await fetch(`${base}/intents`)).json();
+    assert.equal(all.length, 2, 'no filter still returns everything');
+
+    const pending = await (await fetch(`${base}/intents?status=pending`)).json();
+    assert.deepEqual(pending.map((i) => i.id), [openId], 'only the open one');
+
+    const decided = await (await fetch(`${base}/intents?status=decided`)).json();
+    assert.deepEqual(decided.map((i) => i.id), [doneId]);
+
+    const bad = await fetch(`${base}/intents?status=banana`);
+    assert.equal(bad.status, 400, 'an unknown filter must fail loudly, not list everything');
+  } finally {
+    server.close();
+  }
+});


### PR DESCRIPTION
**The queue petrus taps has never been able to shrink.** `GET /intents` ignored query parameters and returned every intent ever created, so decided items sat in the list looking open.

**Today that turned into a near-miss.** Intent `683c5056` was an echo of a migration fix that had already run. claudeMB spotted it and deliberately did *not* re-run it — re-running would have `pkill`ed a healthy rsync in the middle of a 156 GB copy. The queue handed him a live grenade because it could not tell him the pin was already pulled.

**Change:** `?status=pending` and `?status=decided` filter the list. No parameter behaves exactly as before, so existing callers are untouched. An unknown value returns 400 rather than silently listing everything — a filter that quietly does nothing is precisely how this survived unnoticed.

**Verification:** new test covers unfiltered, both filters, and the 400. I confirmed it **fails against the unpatched source** before accepting it. Full suite 289 pass, 0 fail.

This is the server half. The client half — CodeWatch asking for `?status=pending` — is @claudeMB's, and is what actually makes the list on the phone stop growing.