### PR TITLE
config: <name>_file secrets; poller heartbeat, nudge gate, one-time health alert (fixes #86)

### DIFF
--- a/bin/cli.mjs
+++ b/bin/cli.mjs
@@ -559,7 +559,7 @@ async function main() {
       const pollerApiKey = config?.poller?.api_key || config?.poller?.apiKey || config?.intent?.apiKey || process.env.ANTIGRAVITY_API_KEY;
       const pollerHandle = config?.poller?.handle;
       if (!pollerRooms || !pollerApiKey || !pollerHandle) {
-        console.error('Error: poller.rooms, poller.api_key, and poller.handle must be set in config');
+        console.error('Error: poller.rooms, poller.api_key (or poller.api_key_file), and poller.handle must be set in config');
         process.exit(1);
       }
       await startRoomPoller({

--- a/bin/iak-degradation-watch.mjs
+++ b/bin/iak-degradation-watch.mjs
@@ -30,6 +30,7 @@
 // Flags: --once (single tick, for tests/cron), --dry-run (print, don't post).
 
 import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { resolveSecretFiles } from '../src/config.mjs';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -47,8 +48,9 @@ function loadConfig() {
   if (!watch || !Array.isArray(watch.agents) || watch.agents.length === 0) {
     throw new Error('config missing degradation_watch.agents');
   }
+  resolveSecretFiles(cfg);
   const apiKey = watch.api_key || cfg.poller?.api_key;
-  if (!apiKey) throw new Error('no api key (degradation_watch.api_key or poller.api_key)');
+  if (!apiKey) throw new Error('no api key (degradation_watch.api_key[_file] or poller.api_key[_file])');
   return {
     intervalSec: watch.interval_sec || 300,
     alertRoom: watch.alert_room || 'thinkoff-development',

--- a/config/codex.desktop.example.json
+++ b/config/codex.desktop.example.json
@@ -32,7 +32,8 @@
       "feature-admin-planning",
       "lattice-qcd"
     ],
-    "api_key": "antfarm_xxx",
+    "api_key_file": "/Users/you/.iak/codexmb_api_key.txt",
+  "heartbeat_file": "/tmp/iak-poller.heartbeat",
     "handle": "@CodexMB",
     "interval_sec": 60,
     "nudge_mode": "command",

--- a/scripts/codex-webhook-supervisor.sh
+++ b/scripts/codex-webhook-supervisor.sh
@@ -23,6 +23,12 @@ PORT=8791
 INTERVAL=30
 CF_LOG=/tmp/codex-cloudflared-webhook.log
 LOG=/tmp/codex-webhook-supervisor.log
+# The room poller's heartbeat (poller.heartbeat_file in the IAK config). The
+# nudge refuses to type while it is stale, and the health alert below posts
+# once when it goes stale and once when it returns (issue #86).
+POLLER_HEARTBEAT="${IAK_POLLER_HEARTBEAT:-/tmp/iak-poller.heartbeat}"
+POLLER_ERR_LOG="${IAK_POLLER_ERR_LOG:-/tmp/codexmb.poller.err}"
+HEALTH_ALERT="$HOME/ide-agent-kit/scripts/poller-health-alert.mjs"
 
 log(){ echo "[$(date '+%F %T')] $*" | tee -a "$LOG"; }
 
@@ -58,6 +64,7 @@ start_receiver(){
     WEBHOOK_WAKE_LOG="/tmp/codex-webhook-wake.log" \
     IAK_CODEX_APP_NAME="ChatGPT" \
     IAK_NUDGE_TEXT="check rooms [codex]" \
+    IAK_POLLER_HEARTBEAT="$POLLER_HEARTBEAT" \
       "$NODE_BIN" "$RECEIVER" >>/tmp/codex-webhook-wake.log 2>&1 &
       sleep 1
       if kill -0 $! 2>/dev/null; then log "receiver started"; else log "receiver FAILED to start"; fi
@@ -108,9 +115,18 @@ URL=$(get_url)
 # (the PUT is idempotent).
 REREGISTER_EVERY="${REREGISTER_EVERY:-30}"
 LOOPS=0
+poller_health(){
+  [ -f "$HEALTH_ALERT" ] || return 0
+  # Key via environment only (same rule as register()).
+  IAK_ALERT_KEY="$KEY" IAK_POLLER_HEARTBEAT="$POLLER_HEARTBEAT" IAK_POLLER_ERR_LOG="$POLLER_ERR_LOG" \
+  IAK_ALERT_LABEL="@codexmb room poller" \
+    "$(command -v node || echo /usr/local/bin/node)" "$HEALTH_ALERT" >>"$LOG" 2>&1 || true
+}
+
 while true; do
   sleep "$INTERVAL"
   start_receiver
+  poller_health
   if ! pgrep -f "cloudflared tunnel --url http://127.0.0.1:$PORT" >/dev/null; then
     log "cloudflared died; restarting"
     start_tunnel

--- a/scripts/poller-health-alert.mjs
+++ b/scripts/poller-health-alert.mjs
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: AGPL-3.0-only
+// Post ONE room alert when the room poller stops heartbeating, and one
+// all-clear when it comes back. Run from a supervisor loop; idempotent via a
+// state file. A launchd job with KeepAlive that dies on start restarts every
+// few seconds and writes only to a log nobody reads (1134 lines on
+// 2026-09-01, issue #86) - this is the line that reaches the phone instead.
+//
+// Env: IAK_ALERT_KEY (required; the room API key, never an argv),
+//      IAK_POLLER_HEARTBEAT (default /tmp/iak-poller.heartbeat),
+//      IAK_POLLER_MAX_AGE_SEC (default 180),
+//      IAK_POLLER_ERR_LOG (optional; last line is quoted in the alert),
+//      IAK_ALERT_ROOM (default thinkoff-development),
+//      IAK_ALERT_STATE (default /tmp/iak-poller-alert.state),
+//      IAK_ALERT_BASE (default https://groupmind.one/api/v1),
+//      IAK_ALERT_LABEL (default "room poller", names the job in the text).
+import { existsSync, statSync, readFileSync, writeFileSync, unlinkSync } from 'node:fs';
+
+const key = process.env.IAK_ALERT_KEY;
+const heartbeat = process.env.IAK_POLLER_HEARTBEAT || '/tmp/iak-poller.heartbeat';
+const maxAge = Number(process.env.IAK_POLLER_MAX_AGE_SEC || 180);
+const errLog = process.env.IAK_POLLER_ERR_LOG || '';
+const room = process.env.IAK_ALERT_ROOM || 'thinkoff-development';
+const stateFile = process.env.IAK_ALERT_STATE || '/tmp/iak-poller-alert.state';
+const base = (process.env.IAK_ALERT_BASE || 'https://groupmind.one/api/v1').replace(/\/$/, '');
+const label = process.env.IAK_ALERT_LABEL || 'room poller';
+
+if (!key) {
+  console.error('poller-health-alert: IAK_ALERT_KEY missing');
+  process.exit(2);
+}
+
+export function heartbeatAge(path, now = Date.now()) {
+  if (!existsSync(path)) return Infinity;
+  return Math.round((now - statSync(path).mtimeMs) / 1000);
+}
+
+export function lastLine(path) {
+  try {
+    const lines = readFileSync(path, 'utf8').split('\n').filter(Boolean);
+    return lines.length ? lines[lines.length - 1].slice(0, 300) : '';
+  } catch {
+    return '';
+  }
+}
+
+async function post(body) {
+  const res = await fetch(`${base}/rooms/${encodeURIComponent(room)}/messages`, {
+    method: 'POST',
+    headers: { 'X-API-Key': key, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ body })
+  });
+  if (!res.ok) throw new Error(`room post failed: HTTP ${res.status}`);
+}
+
+const age = heartbeatAge(heartbeat);
+const down = age > maxAge;
+const alerted = existsSync(stateFile);
+
+if (down && !alerted) {
+  const err = errLog ? lastLine(errLog) : '';
+  const since = age === Infinity ? 'no heartbeat file' : `last heartbeat ${age}s ago`;
+  await post(`⚠️ ${label} is down (${since}, heartbeat ${heartbeat}).` + (err ? `\nLast error: ${err}` : '') +
+    '\nGUI nudges are suspended until it heartbeats again; this alert is posted once.');
+  writeFileSync(stateFile, new Date().toISOString() + '\n');
+  console.log('alert posted');
+} else if (!down && alerted) {
+  await post(`✅ ${label} is back (heartbeat ${age}s old).`);
+  unlinkSync(stateFile);
+  console.log('all-clear posted');
+} else {
+  console.log(down ? 'down, already alerted' : 'healthy');
+}

--- a/scripts/poller-health-alert.mjs
+++ b/scripts/poller-health-alert.mjs
@@ -13,7 +13,9 @@
 //      IAK_ALERT_ROOM (default thinkoff-development),
 //      IAK_ALERT_STATE (default /tmp/iak-poller-alert.state),
 //      IAK_ALERT_BASE (default https://groupmind.one/api/v1),
-//      IAK_ALERT_LABEL (default "room poller", names the job in the text).
+//      IAK_ALERT_LABEL (default "room poller", names the job in the text),
+//      IAK_ALERT_TIMEOUT_MS (default 15000; a stalled POST must not block the
+//      supervisor loop - codex review of PR #87).
 import { existsSync, statSync, readFileSync, writeFileSync, unlinkSync } from 'node:fs';
 
 const key = process.env.IAK_ALERT_KEY;
@@ -24,6 +26,7 @@ const room = process.env.IAK_ALERT_ROOM || 'thinkoff-development';
 const stateFile = process.env.IAK_ALERT_STATE || '/tmp/iak-poller-alert.state';
 const base = (process.env.IAK_ALERT_BASE || 'https://groupmind.one/api/v1').replace(/\/$/, '');
 const label = process.env.IAK_ALERT_LABEL || 'room poller';
+const timeoutMs = Number(process.env.IAK_ALERT_TIMEOUT_MS || 15000);
 
 if (!key) {
   console.error('poller-health-alert: IAK_ALERT_KEY missing');
@@ -48,7 +51,8 @@ async function post(body) {
   const res = await fetch(`${base}/rooms/${encodeURIComponent(room)}/messages`, {
     method: 'POST',
     headers: { 'X-API-Key': key, 'Content-Type': 'application/json' },
-    body: JSON.stringify({ body })
+    body: JSON.stringify({ body }),
+    signal: AbortSignal.timeout(timeoutMs)
   });
   if (!res.ok) throw new Error(`room post failed: HTTP ${res.status}`);
 }
@@ -57,17 +61,24 @@ const age = heartbeatAge(heartbeat);
 const down = age > maxAge;
 const alerted = existsSync(stateFile);
 
-if (down && !alerted) {
-  const err = errLog ? lastLine(errLog) : '';
-  const since = age === Infinity ? 'no heartbeat file' : `last heartbeat ${age}s ago`;
-  await post(`⚠️ ${label} is down (${since}, heartbeat ${heartbeat}).` + (err ? `\nLast error: ${err}` : '') +
-    '\nGUI nudges are suspended until it heartbeats again; this alert is posted once.');
-  writeFileSync(stateFile, new Date().toISOString() + '\n');
-  console.log('alert posted');
-} else if (!down && alerted) {
-  await post(`✅ ${label} is back (heartbeat ${age}s old).`);
-  unlinkSync(stateFile);
-  console.log('all-clear posted');
-} else {
-  console.log(down ? 'down, already alerted' : 'healthy');
+// A failed or timed-out post leaves the state untouched, so the next loop
+// simply tries again; the supervisor never waits longer than timeoutMs.
+try {
+  if (down && !alerted) {
+    const err = errLog ? lastLine(errLog) : '';
+    const since = age === Infinity ? 'no heartbeat file' : `last heartbeat ${age}s ago`;
+    await post(`⚠️ ${label} is down (${since}, heartbeat ${heartbeat}).` + (err ? `\nLast error: ${err}` : '') +
+      '\nGUI nudges are suspended until it heartbeats again; this alert is posted once.');
+    writeFileSync(stateFile, new Date().toISOString() + '\n');
+    console.log('alert posted');
+  } else if (!down && alerted) {
+    await post(`✅ ${label} is back (heartbeat ${age}s old).`);
+    unlinkSync(stateFile);
+    console.log('all-clear posted');
+  } else {
+    console.log(down ? 'down, already alerted' : 'healthy');
+  }
+} catch (e) {
+  console.error(`poller-health-alert: post failed, will retry next loop: ${e.message}`);
+  process.exit(1);
 }

--- a/src/config.mjs
+++ b/src/config.mjs
@@ -2,6 +2,7 @@
 
 import { readFileSync, existsSync } from 'node:fs';
 import { resolve } from 'node:path';
+import { homedir } from 'node:os';
 
 const DEFAULT_CONFIG = {
   listen: { host: '127.0.0.1', port: 8787 },
@@ -75,11 +76,46 @@ const DEFAULT_CONFIG = {
   }
 };
 
+// Secrets may be given as `<name>_file` instead of inline: the file's trimmed
+// contents become `<name>`. A file reference is the safer default for a key
+// (it never lands in a config that gets pasted into a room), and codex.json was
+// written that way - which the CLI silently did not read, so its poller
+// crash-looped 1134 times behind launchd KeepAlive (issue #86, 2026-09-01).
+// An inline value wins when both are present; a missing file is an error with
+// the path in it, never a silent empty key.
+const SECRET_FILE_FIELDS = [
+  ['poller', 'api_key'],
+  ['dm_poller', 'api_key'],
+  ['xfor', 'api_key'],
+  ['intent', 'apiKey'],
+  ['degradation_watch', 'api_key']
+];
+
+export function readSecretFile(path) {
+  const expanded = path.startsWith('~/') ? resolve(homedir(), path.slice(2)) : resolve(path);
+  if (!existsSync(expanded)) throw new Error(`secret file not found: ${expanded}`);
+  const value = readFileSync(expanded, 'utf8').trim();
+  if (!value) throw new Error(`secret file is empty: ${expanded}`);
+  return value;
+}
+
+export function resolveSecretFiles(cfg, fields = SECRET_FILE_FIELDS) {
+  for (const [section, key] of fields) {
+    const block = cfg?.[section];
+    if (!block || typeof block !== 'object') continue;
+    const fileKey = `${key === 'apiKey' ? 'api_key' : key}_file`;
+    const file = block[fileKey];
+    if (!file || block[key]) continue;
+    block[key] = readSecretFile(file);
+  }
+  return cfg;
+}
+
 export function loadConfig(configPath) {
   const p = resolve(configPath || 'ide-agent-kit.json');
   if (!existsSync(p)) return { ...DEFAULT_CONFIG };
   const raw = JSON.parse(readFileSync(p, 'utf8'));
-  return {
+  return resolveSecretFiles({
     listen: { ...DEFAULT_CONFIG.listen, ...raw.listen },
     queue: { ...DEFAULT_CONFIG.queue, ...raw.queue },
     receipts: { ...DEFAULT_CONFIG.receipts, ...raw.receipts },
@@ -113,6 +149,8 @@ export function loadConfig(configPath) {
     intent: raw.intent || {},
     memory_api: raw.memory_api || {},
     moltbook: raw.moltbook || {},
-    mcp: raw.mcp || {}
-  };
+    mcp: raw.mcp || {},
+    xfor: raw.xfor || {},
+    degradation_watch: raw.degradation_watch || {}
+  });
 }

--- a/src/config.mjs
+++ b/src/config.mjs
@@ -105,7 +105,11 @@ export function resolveSecretFiles(cfg, fields = SECRET_FILE_FIELDS) {
     if (!block || typeof block !== 'object') continue;
     const fileKey = `${key === 'apiKey' ? 'api_key' : key}_file`;
     const file = block[fileKey];
-    if (!file || block[key]) continue;
+    // Either spelling counts as an inline value: the CLI still honours the
+    // legacy camelCase `apiKey`, so a file must not overrule it either
+    // (codex review of PR #87).
+    const inline = block[key] || block.api_key || block.apiKey;
+    if (!file || inline) continue;
     block[key] = readSecretFile(file);
   }
   return cfg;

--- a/src/room-poller.mjs
+++ b/src/room-poller.mjs
@@ -20,20 +20,6 @@ import { resolveSelfHandle, isSelfSender } from './common/handles.mjs';
 
 const SEEN_FILE_DEFAULT = '/tmp/iak-seen-ids.txt';
 const NOTIFY_FILE_DEFAULT = '/tmp/iak-new-messages.txt';
-const HEARTBEAT_FILE_DEFAULT = '/tmp/iak-poller.heartbeat';
-
-// The poller's liveness signal for everything that must not act while it is
-// down: the GUI nudge (a nudge with no seen-state re-answers every open
-// mention) and the supervisor's one-time alert. A crash-looping launchd job
-// leaves no other trace a script can read (issue #86).
-export function writeHeartbeat(path) {
-  try {
-    writeFileSync(path, new Date().toISOString() + '\n');
-    return true;
-  } catch {
-    return false;
-  }
-}
 
 function loadSeenIds(path) {
   try {
@@ -77,7 +63,6 @@ export function checkRoomMessages(config) {
 
 export async function startRoomPoller({ rooms, apiKey, handle, interval, config, sessionOpt }) {
   const seenFile = config?.poller?.seen_file || SEEN_FILE_DEFAULT;
-  const heartbeatFile = config?.poller?.heartbeat_file || HEARTBEAT_FILE_DEFAULT;
   const notifyFile = config?.poller?.notification_file || NOTIFY_FILE_DEFAULT;
   const queuePath = config?.queue?.path || './ide-agent-queue.jsonl';
   const session = sessionOpt || config?.tmux?.ide_session || config?.tmux?.default_session || 'claude';
@@ -111,7 +96,6 @@ export async function startRoomPoller({ rooms, apiKey, handle, interval, config,
     console.warn('  ⚠️  wakes will silently do nothing. Set the command or switch modes.');
   }
   console.log(`  seen file: ${seenFile}`);
-  console.log(`  heartbeat: ${heartbeatFile}`);
   console.log(`  queue: ${queuePath}`);
   console.log('  auto-ack: disabled (real replies only)');
 
@@ -130,7 +114,6 @@ export async function startRoomPoller({ rooms, apiKey, handle, interval, config,
   }
 
   async function poll() {
-    writeHeartbeat(heartbeatFile);
     let newCount = 0;
     const newMessages = [];
     for (const room of rooms) {

--- a/src/room-poller.mjs
+++ b/src/room-poller.mjs
@@ -20,6 +20,20 @@ import { resolveSelfHandle, isSelfSender } from './common/handles.mjs';
 
 const SEEN_FILE_DEFAULT = '/tmp/iak-seen-ids.txt';
 const NOTIFY_FILE_DEFAULT = '/tmp/iak-new-messages.txt';
+const HEARTBEAT_FILE_DEFAULT = '/tmp/iak-poller.heartbeat';
+
+// The poller's liveness signal for everything that must not act while it is
+// down: the GUI nudge (a nudge with no seen-state re-answers every open
+// mention) and the supervisor's one-time alert. A crash-looping launchd job
+// leaves no other trace a script can read (issue #86).
+export function writeHeartbeat(path) {
+  try {
+    writeFileSync(path, new Date().toISOString() + '\n');
+    return true;
+  } catch {
+    return false;
+  }
+}
 
 function loadSeenIds(path) {
   try {
@@ -63,6 +77,7 @@ export function checkRoomMessages(config) {
 
 export async function startRoomPoller({ rooms, apiKey, handle, interval, config, sessionOpt }) {
   const seenFile = config?.poller?.seen_file || SEEN_FILE_DEFAULT;
+  const heartbeatFile = config?.poller?.heartbeat_file || HEARTBEAT_FILE_DEFAULT;
   const notifyFile = config?.poller?.notification_file || NOTIFY_FILE_DEFAULT;
   const queuePath = config?.queue?.path || './ide-agent-queue.jsonl';
   const session = sessionOpt || config?.tmux?.ide_session || config?.tmux?.default_session || 'claude';
@@ -96,6 +111,7 @@ export async function startRoomPoller({ rooms, apiKey, handle, interval, config,
     console.warn('  ⚠️  wakes will silently do nothing. Set the command or switch modes.');
   }
   console.log(`  seen file: ${seenFile}`);
+  console.log(`  heartbeat: ${heartbeatFile}`);
   console.log(`  queue: ${queuePath}`);
   console.log('  auto-ack: disabled (real replies only)');
 
@@ -114,6 +130,7 @@ export async function startRoomPoller({ rooms, apiKey, handle, interval, config,
   }
 
   async function poll() {
+    writeHeartbeat(heartbeatFile);
     let newCount = 0;
     const newMessages = [];
     for (const room of rooms) {

--- a/src/team-relay/room-poller.mjs
+++ b/src/team-relay/room-poller.mjs
@@ -151,8 +151,26 @@ export function checkRoomMessages(config) {
   }
 }
 
+const HEARTBEAT_FILE_DEFAULT = '/tmp/iak-poller.heartbeat';
+
+// The poller's liveness signal for everything that must not act while it is
+// down: the GUI nudge (a nudge with no seen-state re-answers every open
+// mention) and the supervisor's one-time alert. A crash-looping launchd job
+// leaves no other trace a script can read (issue #86). This is the module the
+// CLI actually runs - src/room-poller.mjs is the unimported legacy copy
+// (codex review of PR #87 caught the heartbeat landing there first).
+export function writeHeartbeat(path) {
+  try {
+    writeFileSync(path, new Date().toISOString() + '\n');
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export async function startRoomPoller({ rooms, apiKey, handle, interval, config, sessionOpt }) {
   const seenFile = config?.poller?.seen_file || SEEN_FILE_DEFAULT;
+  const heartbeatFile = config?.poller?.heartbeat_file || HEARTBEAT_FILE_DEFAULT;
   const notifyFile = config?.poller?.notification_file || NOTIFY_FILE_DEFAULT;
   const queuePath = config?.queue?.path || './ide-agent-queue.jsonl';
   const session = sessionOpt || config?.tmux?.ide_session || config?.tmux?.default_session || 'claude';
@@ -202,6 +220,7 @@ export async function startRoomPoller({ rooms, apiKey, handle, interval, config,
     console.log(`  nudge command: ${nudgeCommandText || '(missing)'}`);
   }
   console.log(`  seen file: ${seenFile}`);
+  console.log(`  heartbeat: ${heartbeatFile}`);
   if (dmEnabled) {
     console.log(`  direct messages: enabled`);
     console.log(`    dm handle: ${dmHandle}`);
@@ -248,6 +267,7 @@ export async function startRoomPoller({ rooms, apiKey, handle, interval, config,
     if (roomPollInFlight) return;
     roomPollInFlight = true;
     try {
+    writeHeartbeat(heartbeatFile);
     let newCount = 0;
     let hasOwnerMessage = false;
     let hasMention = false;

--- a/test/config.test.mjs
+++ b/test/config.test.mjs
@@ -5,7 +5,7 @@ import { strict as assert } from 'node:assert';
 import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { loadConfig } from '../src/config.mjs';
+import { loadConfig, resolveSecretFiles } from '../src/config.mjs';
 
 const tempPaths = [];
 
@@ -104,5 +104,44 @@ describe('config', () => {
     assert.equal(cfg.intent.userId, 'u');
     assert.equal(cfg.memory_api.token, 't');
     assert.equal(cfg.moltbook.accounts[0].name, 'claudemm');
+  });
+});
+
+describe('secret file references (issue #86)', () => {
+  let dir;
+  afterEach(() => { if (dir) rmSync(dir, { recursive: true, force: true }); dir = null; });
+
+  it('reads poller.api_key_file into poller.api_key, trimmed', () => {
+    dir = mkdtempSync(join(tmpdir(), 'iak-secret-'));
+    writeFileSync(join(dir, 'key.txt'), '  xfb_secret_from_file\n');
+    writeFileSync(join(dir, 'c.json'), JSON.stringify({ poller: { rooms: 'r', handle: '@x', api_key_file: join(dir, 'key.txt') } }));
+    const cfg = loadConfig(join(dir, 'c.json'));
+    assert.equal(cfg.poller.api_key, 'xfb_secret_from_file');
+  });
+
+  it('covers dm_poller, xfor and intent too', () => {
+    dir = mkdtempSync(join(tmpdir(), 'iak-secret-'));
+    writeFileSync(join(dir, 'k'), 'K1');
+    const cfg = loadConfig(join(dir, 'c.json'));
+    assert.equal(cfg.poller.api_key, '');
+    writeFileSync(join(dir, 'c.json'), JSON.stringify({
+      dm_poller: { api_key_file: join(dir, 'k') },
+      xfor: { api_key_file: join(dir, 'k') },
+      intent: { api_key_file: join(dir, 'k') }
+    }));
+    const c2 = loadConfig(join(dir, 'c.json'));
+    assert.equal(c2.dm_poller.api_key, 'K1');
+    assert.equal(c2.xfor.api_key, 'K1');
+    assert.equal(c2.intent.apiKey, 'K1');
+  });
+
+  it('an inline key wins over the file, and a missing file names its path', () => {
+    dir = mkdtempSync(join(tmpdir(), 'iak-secret-'));
+    writeFileSync(join(dir, 'k'), 'FILEKEY');
+    const both = resolveSecretFiles({ poller: { api_key: 'INLINE', api_key_file: join(dir, 'k') } });
+    assert.equal(both.poller.api_key, 'INLINE');
+    assert.throws(() => resolveSecretFiles({ poller: { api_key_file: join(dir, 'nope') } }), /secret file not found: .*nope/);
+    writeFileSync(join(dir, 'empty'), '\n');
+    assert.throws(() => resolveSecretFiles({ poller: { api_key_file: join(dir, 'empty') } }), /secret file is empty/);
   });
 });

--- a/test/config.test.mjs
+++ b/test/config.test.mjs
@@ -140,6 +140,10 @@ describe('secret file references (issue #86)', () => {
     writeFileSync(join(dir, 'k'), 'FILEKEY');
     const both = resolveSecretFiles({ poller: { api_key: 'INLINE', api_key_file: join(dir, 'k') } });
     assert.equal(both.poller.api_key, 'INLINE');
+    // legacy camelCase spelling is inline too (codex review of PR #87)
+    const legacy = resolveSecretFiles({ poller: { apiKey: 'LEGACY', api_key_file: join(dir, 'k') } });
+    assert.equal(legacy.poller.apiKey, 'LEGACY');
+    assert.equal(legacy.poller.api_key, undefined);
     assert.throws(() => resolveSecretFiles({ poller: { api_key_file: join(dir, 'nope') } }), /secret file not found: .*nope/);
     writeFileSync(join(dir, 'empty'), '\n');
     assert.throws(() => resolveSecretFiles({ poller: { api_key_file: join(dir, 'empty') } }), /secret file is empty/);

--- a/test/poller-health.test.mjs
+++ b/test/poller-health.test.mjs
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Issue #86: a nudge must not fire while the room poller is down, and the
+// supervisor must say so once (and once more when it is back).
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync, writeFileSync, existsSync, utimesSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { spawnSync, execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+const execFileP = promisify(execFile);
+import { createServer } from 'node:http';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+import { writeHeartbeat } from '../src/room-poller.mjs';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const nudge = path.join(repoRoot, 'tools', 'codex_gui_nudge.sh');
+const alert = path.join(repoRoot, 'scripts', 'poller-health-alert.mjs');
+
+test('writeHeartbeat stamps the file with the current time', () => {
+  const dir = mkdtempSync(path.join(tmpdir(), 'iak-hb-'));
+  try {
+    const hb = path.join(dir, 'hb');
+    assert.equal(writeHeartbeat(hb), true);
+    assert.match(readFileSync(hb, 'utf8'), /^\d{4}-\d{2}-\d{2}T/);
+  } finally { rmSync(dir, { recursive: true, force: true }); }
+});
+
+test('codex_gui_nudge refuses to type while the poller heartbeat is missing or stale', () => {
+  const dir = mkdtempSync(path.join(tmpdir(), 'iak-nudge-'));
+  try {
+    const log = path.join(dir, 'nudge.log');
+    const missing = spawnSync('bash', [nudge], { encoding: 'utf8', env: { ...process.env, IAK_POLLER_HEARTBEAT: path.join(dir, 'none'), IAK_CODEX_NUDGE_LOG: log } });
+    assert.equal(missing.status, 1);
+    assert.match(readFileSync(log, 'utf8'), /ABORT poller down \(no heartbeat/);
+
+    const hb = path.join(dir, 'hb');
+    writeFileSync(hb, 'x');
+    const old = new Date(Date.now() - 600_000);
+    utimesSync(hb, old, old);
+    const stale = spawnSync('bash', [nudge], { encoding: 'utf8', env: { ...process.env, IAK_POLLER_HEARTBEAT: hb, IAK_POLLER_MAX_AGE_SEC: '180', IAK_CODEX_NUDGE_LOG: log } });
+    assert.equal(stale.status, 1);
+    assert.match(readFileSync(log, 'utf8'), /ABORT poller down \(heartbeat \d+s old, max 180s\)/);
+  } finally { rmSync(dir, { recursive: true, force: true }); }
+});
+
+test('poller-health-alert posts once when down, once when back, nothing in between', async () => {
+  const dir = mkdtempSync(path.join(tmpdir(), 'iak-alert-'));
+  const posts = [];
+  const server = createServer((req, res) => {
+    let raw = '';
+    req.on('data', (c) => { raw += c; });
+    req.on('end', () => {
+      posts.push({ url: req.url, key: req.headers['x-api-key'], body: JSON.parse(raw).body });
+      res.writeHead(200, { 'Content-Type': 'application/json' }); res.end('{}');
+    });
+  });
+  await new Promise((r) => server.listen(0, '127.0.0.1', r));
+  const base = `http://127.0.0.1:${server.address().port}`;
+  try {
+    const hb = path.join(dir, 'hb'); const state = path.join(dir, 'state'); const err = path.join(dir, 'err.log');
+    writeFileSync(err, 'boot\nError: poller.rooms, poller.api_key (or poller.api_key_file), and poller.handle must be set in config\n');
+    const env = { ...process.env, IAK_ALERT_KEY: 'k1', IAK_POLLER_HEARTBEAT: hb, IAK_POLLER_ERR_LOG: err, IAK_ALERT_STATE: state, IAK_ALERT_BASE: base, IAK_ALERT_ROOM: 'r', IAK_ALERT_LABEL: 'test poller' };
+    // async spawn: the stub server lives in THIS process, so a spawnSync
+    // child could never be answered (deadlock, found writing this test)
+    const run = () => execFileP('node', [alert], { encoding: 'utf8', env });
+
+    await run();
+    assert.equal(posts.length, 1);
+    assert.equal(posts[0].url, '/rooms/r/messages');
+    assert.equal(posts[0].key, 'k1');
+    assert.match(posts[0].body, /test poller is down \(no heartbeat file/);
+    assert.match(posts[0].body, /Last error: Error: poller\.rooms/);
+    assert.ok(existsSync(state));
+
+    await run();
+    assert.equal(posts.length, 1, 'second run must not post again');
+
+    writeHeartbeat(hb);
+    await run();
+    assert.equal(posts.length, 2);
+    assert.match(posts[1].body, /test poller is back/);
+    assert.ok(!existsSync(state));
+
+    await run(); assert.equal(posts.length, 2, 'healthy + no state = silent');
+  } finally { server.close(); rmSync(dir, { recursive: true, force: true }); }
+});

--- a/test/poller-health.test.mjs
+++ b/test/poller-health.test.mjs
@@ -2,7 +2,7 @@
 // Issue #86: a nudge must not fire while the room poller is down, and the
 // supervisor must say so once (and once more when it is back).
 import assert from 'node:assert/strict';
-import { mkdtempSync, rmSync, writeFileSync, existsSync, utimesSync, readFileSync } from 'node:fs';
+import { mkdtempSync, rmSync, writeFileSync, existsSync, utimesSync, readFileSync, chmodSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { spawnSync, execFile } from 'node:child_process';
@@ -11,7 +11,7 @@ const execFileP = promisify(execFile);
 import { createServer } from 'node:http';
 import test from 'node:test';
 import { fileURLToPath } from 'node:url';
-import { writeHeartbeat } from '../src/room-poller.mjs';
+import { writeHeartbeat, startRoomPoller } from '../src/team-relay/room-poller.mjs';
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const nudge = path.join(repoRoot, 'tools', 'codex_gui_nudge.sh');
@@ -84,4 +84,32 @@ test('poller-health-alert posts once when down, once when back, nothing in betwe
 
     await run(); assert.equal(posts.length, 2, 'healthy + no state = silent');
   } finally { server.close(); rmSync(dir, { recursive: true, force: true }); }
+});
+
+test('the poller the CLI actually runs writes the heartbeat on every poll', async () => {
+  // src/team-relay/room-poller.mjs is what bin/cli.mjs imports; a stub curl on
+  // PATH keeps it off the network (same trick as the ioreg stub tests).
+  const dir = mkdtempSync(path.join(tmpdir(), 'iak-live-'));
+  const stub = path.join(dir, 'curl');
+  writeFileSync(stub, '#!/bin/sh\necho "[]"\n');
+  chmodSync(stub, 0o755);
+  const savedPath = process.env.PATH;
+  process.env.PATH = `${dir}:${savedPath}`;
+  const hb = path.join(dir, 'hb');
+  let timers;
+  try {
+    timers = await startRoomPoller({
+      rooms: ['r'], apiKey: 'k', handle: '@t', interval: 1,
+      config: { poller: { seen_file: path.join(dir, 'seen'), notification_file: path.join(dir, 'notify'), heartbeat_file: hb, nudge_mode: 'none' }, queue: { path: path.join(dir, 'q.jsonl') } }
+    });
+    assert.ok(existsSync(hb), 'heartbeat written by the first poll');
+    const first = readFileSync(hb, 'utf8');
+    await new Promise((r) => setTimeout(r, 1300));
+    assert.notEqual(readFileSync(hb, 'utf8'), first, 'heartbeat refreshed by the interval poll');
+  } finally {
+    if (timers?.roomTimer) clearInterval(timers.roomTimer);
+    if (timers?.dmTimer) clearInterval(timers.dmTimer);
+    process.env.PATH = savedPath;
+    rmSync(dir, { recursive: true, force: true });
+  }
 });

--- a/test/poller-health.test.mjs
+++ b/test/poller-health.test.mjs
@@ -113,3 +113,20 @@ test('the poller the CLI actually runs writes the heartbeat on every poll', asyn
     rmSync(dir, { recursive: true, force: true });
   }
 });
+
+test('poller-health-alert gives up on a stalled POST within the timeout and keeps no state', async () => {
+  const dir = mkdtempSync(path.join(tmpdir(), 'iak-alert-stall-'));
+  let hits = 0;
+  const server = createServer((req) => { hits++; req.on('data', () => {}); /* never answer */ });
+  await new Promise((r) => server.listen(0, '127.0.0.1', r));
+  const base = `http://127.0.0.1:${server.address().port}`;
+  try {
+    const state = path.join(dir, 'state');
+    const env = { ...process.env, IAK_ALERT_KEY: 'k1', IAK_POLLER_HEARTBEAT: path.join(dir, 'none'), IAK_ALERT_STATE: state, IAK_ALERT_BASE: base, IAK_ALERT_ROOM: 'r', IAK_ALERT_TIMEOUT_MS: '300' };
+    const t0 = Date.now();
+    await assert.rejects(execFileP('node', [alert], { encoding: 'utf8', env }), (e) => /post failed, will retry next loop/.test(e.stderr));
+    assert.ok(Date.now() - t0 < 5000, 'returned promptly, not hung on the socket');
+    assert.equal(hits, 1);
+    assert.ok(!existsSync(state), 'no state file after a failed post, so the next loop retries');
+  } finally { server.closeAllConnections?.(); server.close(); rmSync(dir, { recursive: true, force: true }); }
+});

--- a/tools/codex_gui_nudge.sh
+++ b/tools/codex_gui_nudge.sh
@@ -17,7 +17,16 @@ if [ "$POLLER_HEARTBEAT" != "off" ]; then
         printf '[%s] codex_gui_nudge: ABORT poller down (no heartbeat at %s) - not nudging\n' "$(date -u +%FT%TZ)" "$POLLER_HEARTBEAT" >>"$NUDGE_LOG_EARLY"
         exit 1
     fi
-    HB_AGE=$(( $(date +%s) - $(stat -f %m "$POLLER_HEARTBEAT" 2>/dev/null || stat -c %Y "$POLLER_HEARTBEAT" 2>/dev/null || echo 0) ))
+    # GNU stat: -c %Y is the mtime; its -f is filesystem mode and prints a mount
+    # point (codex review of PR #87). BSD/macOS stat has no -c, so it falls
+    # through to -f %m. Anything non-numeric fails closed: no nudge.
+    HB_MTIME=$(stat -c %Y "$POLLER_HEARTBEAT" 2>/dev/null || stat -f %m "$POLLER_HEARTBEAT" 2>/dev/null || echo "")
+    case "$HB_MTIME" in
+        ''|*[!0-9]*)
+            printf '[%s] codex_gui_nudge: ABORT poller heartbeat mtime unreadable (%s) - not nudging\n' "$(date -u +%FT%TZ)" "${HB_MTIME:-empty}" >>"$NUDGE_LOG_EARLY"
+            exit 1 ;;
+    esac
+    HB_AGE=$(( $(date +%s) - HB_MTIME ))
     if [ "$HB_AGE" -gt "$POLLER_MAX_AGE" ]; then
         printf '[%s] codex_gui_nudge: ABORT poller down (heartbeat %ss old, max %ss) - not nudging\n' "$(date -u +%FT%TZ)" "$HB_AGE" "$POLLER_MAX_AGE" >>"$NUDGE_LOG_EARLY"
         exit 1

--- a/tools/codex_gui_nudge.sh
+++ b/tools/codex_gui_nudge.sh
@@ -3,6 +3,26 @@
 # Never type over the human (petrus 2026-07-13: "tmux should not write if i
 # am writing!"). Skip this nudge cycle unless the machine is human-idle.
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# Never nudge while the room poller is down. Without its seen-file the app
+# reads the recent window cold and answers every mention that still looks
+# open: three nudges produced five identical reviews on 2026-09-01 while the
+# poller crash-looped under launchd (issue #86). The poller touches a
+# heartbeat every cycle; stale or missing = down. Set IAK_POLLER_HEARTBEAT=off
+# only for a setup that has no poller at all.
+POLLER_HEARTBEAT="${IAK_POLLER_HEARTBEAT:-/tmp/iak-poller.heartbeat}"
+POLLER_MAX_AGE="${IAK_POLLER_MAX_AGE_SEC:-180}"
+NUDGE_LOG_EARLY="${IAK_CODEX_NUDGE_LOG:-/tmp/codex_gui_nudge.log}"
+if [ "$POLLER_HEARTBEAT" != "off" ]; then
+    if [ ! -f "$POLLER_HEARTBEAT" ]; then
+        printf '[%s] codex_gui_nudge: ABORT poller down (no heartbeat at %s) - not nudging\n' "$(date -u +%FT%TZ)" "$POLLER_HEARTBEAT" >>"$NUDGE_LOG_EARLY"
+        exit 1
+    fi
+    HB_AGE=$(( $(date +%s) - $(stat -f %m "$POLLER_HEARTBEAT" 2>/dev/null || stat -c %Y "$POLLER_HEARTBEAT" 2>/dev/null || echo 0) ))
+    if [ "$HB_AGE" -gt "$POLLER_MAX_AGE" ]; then
+        printf '[%s] codex_gui_nudge: ABORT poller down (heartbeat %ss old, max %ss) - not nudging\n' "$(date -u +%FT%TZ)" "$HB_AGE" "$POLLER_MAX_AGE" >>"$NUDGE_LOG_EARLY"
+        exit 1
+    fi
+fi
 # WAIT for an idle window rather than skipping: by the time this script runs
 # the poller has marked the message seen, so skipping would consume it
 # undelivered. Exit 1 on timeout so the caller's failure path applies.


### PR DESCRIPTION
Fixes #86 — all three points.

**1. Root cause: `poller.api_key_file` was never read.** `loadConfig` now resolves `<name>_file` for `poller.api_key`, `dm_poller.api_key`, `xfor.api_key`, `intent.apiKey`, `degradation_watch.api_key` — trimmed, `~/` expanded, inline value (either spelling, incl. legacy `apiKey`) wins, missing/empty file throws with the path. `iak-degradation-watch` uses the same resolver; the `rooms watch` error names `api_key_file`.

**2. Fail loudly once.** The poller touches `poller.heartbeat_file` (default `/tmp/iak-poller.heartbeat`) every cycle. `scripts/poller-health-alert.mjs`, run from the supervisor loop every 30 s, posts ONE room alert when the heartbeat goes stale (quoting the last line of the poller's err log) and ONE all-clear when it returns; idempotent via a state file; key via env only.

**3. No GUI nudge while the poller is down.** `tools/codex_gui_nudge.sh` exits 1 (logged as "ABORT poller down") when the heartbeat is missing or older than `IAK_POLLER_MAX_AGE_SEC` (180) — before any GUI action. `IAK_POLLER_HEARTBEAT=off` opts out for setups without a poller. The supervisor passes the heartbeat path to the receiver so the nudge inherits it.

**After merge, on the MacBook (claudeMB):** pull, add `"heartbeat_file": "/tmp/iak-poller.heartbeat"` (or set `IAK_POLLER_HEARTBEAT` to match) in codex.json's poller block, kickstart the poller and the supervisor, confirm the seen-file and heartbeat appear.

**Tests:** config (4 new), poller-health (3 new: heartbeat, nudge gate, alert once/back/silent against a local HTTP stub). Suite 295/295. Codex's P2 (legacy `apiKey` precedence) fixed in cb265aa with a regression test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)