### PR TITLE
mini publisher: heartbeat the human's dashboard, not the agent's own document

### DIFF
--- a/scripts/claudemm-uik-daemon.sh
+++ b/scripts/claudemm-uik-daemon.sh
@@ -18,4 +18,9 @@ export INTENT_USER_ID="$(python3 -c "import json;print(json.load(open('$CONFIG')
 export INTENT_AGENT_HANDLE="@claudemm"
 export INTENT_DEVICE_ID="mac-mini"
 
-exec node "$IAK_DIR/packages/user-intent-kit/bin/uik-daemon.js"
+# launchd starts this with a bare PATH (no Homebrew): resolve node explicitly
+# or the job dies with "exec: node: not found" - which is what kept the
+# publisher an orphan started by hand instead of a KeepAlive service.
+export PATH="/opt/homebrew/bin:/usr/local/bin:$PATH"
+NODE_BIN="$(command -v node || echo /opt/homebrew/bin/node)"
+exec "$NODE_BIN" "$IAK_DIR/packages/user-intent-kit/bin/uik-daemon.js"

--- a/scripts/claudemm-uik-daemon.sh
+++ b/scripts/claudemm-uik-daemon.sh
@@ -9,7 +9,12 @@ CONFIG="$IAK_DIR/config/dogfood.json"
 
 export INTENT_API_BASE="$(python3 -c "import json;print(json.load(open('$CONFIG'))['intent']['baseUrl'])")"
 export INTENT_API_KEY="$(python3 -c "import json;print(json.load(open('$CONFIG'))['intent']['apiKey'])")"
-export INTENT_USER_ID="claudemm"
+# The user whose dashboard these heartbeats feed - the HUMAN (config
+# intent.userId = petrus), never the agent. With "claudemm" here the daemon
+# fed a document nobody looks at while the Intent page listed claudemm as
+# stale for weeks (petrus 2026-09-01: "also claudemm not visible on intent").
+# uik-daemon warns about exactly this; the warning went to a log nobody read.
+export INTENT_USER_ID="$(python3 -c "import json;print(json.load(open('$CONFIG'))['intent']['userId'])")"
 export INTENT_AGENT_HANDLE="@claudemm"
 export INTENT_DEVICE_ID="mac-mini"
 


### PR DESCRIPTION
Petrus 2026-09-01: "also claudemm not visible on intent". `scripts/claudemm-uik-daemon.sh` exported `INTENT_USER_ID="claudemm"` — the agent handle — so the daemon PATCHed `/intent/claudemm/agents/claudemm` (a document nobody views) instead of `/intent/petrus/...`. The device slot `mac-mini` stayed fresh via the other publisher, which hid the fault. `uik-daemon.js` already warns about exactly this misconfiguration; the warning went to a log nobody read.

Fix: read `intent.userId` from `config/dogfood.json` (petrus), the same place the key comes from. Applied live on the Mini by restarting `com.claudemm.mini-publishers`; verification (claudemm fresh in `GET /intent/petrus`) in the room thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)