### PR TITLE
nudge: one wake per window - debounce the second nudge path

### DIFF
--- a/test/poller-health.test.mjs
+++ b/test/poller-health.test.mjs
@@ -2,7 +2,7 @@
 // Issue #86: a nudge must not fire while the room poller is down, and the
 // supervisor must say so once (and once more when it is back).
 import assert from 'node:assert/strict';
-import { mkdtempSync, rmSync, writeFileSync, existsSync, utimesSync, readFileSync, chmodSync } from 'node:fs';
+import { mkdtempSync, rmSync, writeFileSync, existsSync, utimesSync, readFileSync, chmodSync, statSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { spawnSync, execFile } from 'node:child_process';
@@ -129,4 +129,25 @@ test('poller-health-alert gives up on a stalled POST within the timeout and keep
     assert.equal(hits, 1);
     assert.ok(!existsSync(state), 'no state file after a failed post, so the next loop retries');
   } finally { server.closeAllConnections?.(); server.close(); rmSync(dir, { recursive: true, force: true }); }
+});
+
+test('codex_gui_nudge debounces a second nudge inside the window, and only a real injection stamps it', () => {
+  const dir = mkdtempSync(path.join(tmpdir(), 'iak-debounce-'));
+  try {
+    const log = path.join(dir, 'nudge.log');
+    const hb = path.join(dir, 'hb'); writeHeartbeat(hb);
+    const stamp = path.join(dir, 'last');
+    // a nudge injected 10 s ago -> this one is debounced before any GUI or idle wait
+    writeFileSync(stamp, '');
+    const t = new Date(Date.now() - 10_000); utimesSync(stamp, t, t);
+    const r = spawnSync('bash', [nudge], { encoding: 'utf8', env: { ...process.env, IAK_POLLER_HEARTBEAT: hb, IAK_NUDGE_STAMP: stamp, IAK_NUDGE_DEBOUNCE_SEC: '120', IAK_CODEX_NUDGE_LOG: log } });
+    assert.equal(r.status, 0);
+    assert.match(readFileSync(log, 'utf8'), /debounced \(\d+s since last nudge, window 120s\)/);
+    // an aborted nudge (poller down) must not touch the stamp
+    const stale = path.join(dir, 'none');
+    const before = statSync(stamp).mtimeMs;
+    const r2 = spawnSync('bash', [nudge], { encoding: 'utf8', env: { ...process.env, IAK_POLLER_HEARTBEAT: stale, IAK_NUDGE_STAMP: stamp, IAK_CODEX_NUDGE_LOG: log } });
+    assert.equal(r2.status, 1);
+    assert.equal(statSync(stamp).mtimeMs, before, 'abort paths never write the stamp');
+  } finally { rmSync(dir, { recursive: true, force: true }); }
 });

--- a/test/poller-health.test.mjs
+++ b/test/poller-health.test.mjs
@@ -2,7 +2,7 @@
 // Issue #86: a nudge must not fire while the room poller is down, and the
 // supervisor must say so once (and once more when it is back).
 import assert from 'node:assert/strict';
-import { mkdtempSync, rmSync, writeFileSync, existsSync, utimesSync, readFileSync, chmodSync, statSync } from 'node:fs';
+import { mkdtempSync, rmSync, writeFileSync, existsSync, utimesSync, readFileSync, chmodSync, statSync, mkdirSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { spawnSync, execFile } from 'node:child_process';
@@ -149,5 +149,39 @@ test('codex_gui_nudge debounces a second nudge inside the window, and only a rea
     const r2 = spawnSync('bash', [nudge], { encoding: 'utf8', env: { ...process.env, IAK_POLLER_HEARTBEAT: stale, IAK_NUDGE_STAMP: stamp, IAK_CODEX_NUDGE_LOG: log } });
     assert.equal(r2.status, 1);
     assert.equal(statSync(stamp).mtimeMs, before, 'abort paths never write the stamp');
+  } finally { rmSync(dir, { recursive: true, force: true }); }
+});
+
+test('codex_gui_nudge: a reservation held by another nudge debounces this one right before injection', () => {
+  const dir = mkdtempSync(path.join(tmpdir(), 'iak-reserve-'));
+  try {
+    const log = path.join(dir, 'nudge.log');
+    const hb = path.join(dir, 'hb'); writeHeartbeat(hb);
+    const stamp = path.join(dir, 'last');
+    mkdirSync(stamp + '.lock'); // the other process is injecting right now
+    // stubs so the run passes the screen-lock and human-idle checks and reaches
+    // the reservation: ioreg (idle guard), a fake python that reports
+    // "unlocked" and "idle", and an osascript that must never be reached
+    const stubDir = path.join(dir, 'bin'); mkdirSync(stubDir);
+    const mk = (name, body) => { const f = path.join(stubDir, name); writeFileSync(f, body); chmodSync(f, 0o755); return f; };
+    mk('ioreg', '#!/bin/sh\necho \'| "HIDIdleTime" = 999999999999\'\n');
+    const py = mk('fakepy', '#!/bin/sh\n[ "$1" = "-" ] && echo unlocked\nexit 0\n');
+    mk('osascript', '#!/bin/sh\necho "MUST NOT RUN" >&2; exit 99\n');
+    const idleCheck = mk('idle.py', '#!/bin/sh\nexit 0\n');
+    const r = spawnSync('bash', [nudge], { encoding: 'utf8', env: { ...process.env, PATH: `${stubDir}:${process.env.PATH}`, IAK_POLLER_HEARTBEAT: hb, IAK_NUDGE_STAMP: stamp, IAK_CODEX_NUDGE_LOG: log, IAK_CLICLICK_BIN: '/nonexistent', IAK_PYTHON_BIN: py, IAK_HUMAN_IDLE_CHECK: idleCheck } });
+    const out = readFileSync(log, 'utf8');
+    assert.equal(r.status, 0, r.stderr);
+    assert.ok(!/MUST NOT RUN/.test(r.stderr), 'no injection while another nudge holds the reservation');
+    assert.match(out, /debounced \(another nudge is injecting right now\)/);
+    assert.ok(existsSync(stamp + '.lock'), 'a reservation held by another process is not released by us');
+    assert.ok(!existsSync(stamp), 'no stamp written by a debounced run');
+    // positive control: with no reservation the same stubs DO reach the
+    // injection (the osascript stub fails), and a failed send leaves no stamp
+    rmSync(stamp + '.lock', { recursive: true, force: true });
+    const r2 = spawnSync('bash', [nudge], { encoding: 'utf8', env: { ...process.env, PATH: `${stubDir}:${process.env.PATH}`, IAK_POLLER_HEARTBEAT: hb, IAK_NUDGE_STAMP: stamp, IAK_CODEX_NUDGE_LOG: log, IAK_CLICLICK_BIN: '/nonexistent', IAK_PYTHON_BIN: py, IAK_HUMAN_IDLE_CHECK: idleCheck } });
+    assert.match(r2.stderr, /MUST NOT RUN/, 'control: the stubs reach the injection point');
+    assert.equal(r2.status, 1, 'a failed injection exits 1');
+    assert.ok(!existsSync(stamp), 'a failed injection writes no stamp');
+    assert.ok(!existsSync(stamp + '.lock'), 'the reservation is released on exit');
   } finally { rmSync(dir, { recursive: true, force: true }); }
 });

--- a/tools/codex_gui_nudge.sh
+++ b/tools/codex_gui_nudge.sh
@@ -55,6 +55,37 @@ if [ -f "$NUDGE_STAMP" ]; then
             fi ;;
     esac
 fi
+# Atomic reservation held across the injection (codex review of PR #89):
+# two nudge processes can both pass the early check, both wait out the idle
+# guard, and both inject. mkdir is atomic; the holder re-checks the stamp
+# inside the reservation, so a nudge that landed while we waited debounces
+# this one. A reservation older than 10 min is a crashed holder.
+NUDGE_LOCK="$NUDGE_STAMP.lock"
+release_nudge() { rmdir "$NUDGE_LOCK" 2>/dev/null || true; }
+reserve_nudge() {
+    if [ -d "$NUDGE_LOCK" ]; then
+        LOCK_MTIME=$(stat -c %Y "$NUDGE_LOCK" 2>/dev/null || stat -f %m "$NUDGE_LOCK" 2>/dev/null || echo 0)
+        case "$LOCK_MTIME" in ''|*[!0-9]*) LOCK_MTIME=0 ;; esac
+        if [ $(( $(date +%s) - LOCK_MTIME )) -gt 600 ]; then rmdir "$NUDGE_LOCK" 2>/dev/null || true; fi
+    fi
+    if ! mkdir "$NUDGE_LOCK" 2>/dev/null; then
+        printf '[%s] codex_gui_nudge: debounced (another nudge is injecting right now)\n' "$(date -u +%FT%TZ)" >>"$NUDGE_LOG_EARLY"
+        exit 0
+    fi
+    trap release_nudge EXIT
+    if [ -f "$NUDGE_STAMP" ]; then
+        LAST_MTIME=$(stat -c %Y "$NUDGE_STAMP" 2>/dev/null || stat -f %m "$NUDGE_STAMP" 2>/dev/null || echo "")
+        case "$LAST_MTIME" in
+            ''|*[!0-9]*) ;;
+            *)
+                SINCE=$(( $(date +%s) - LAST_MTIME ))
+                if [ "$SINCE" -lt "$NUDGE_DEBOUNCE" ]; then
+                    printf '[%s] codex_gui_nudge: debounced at injection (%ss since a nudge that landed while we waited)\n' "$(date -u +%FT%TZ)" "$SINCE" >>"$NUDGE_LOG_EARLY"
+                    exit 0
+                fi ;;
+        esac
+    fi
+}
 if ! "$REPO_ROOT/tools/human-idle-guard.sh" --wait 300; then
     echo "nudge aborted: human continuously active" >&2
     exit 1
@@ -169,8 +200,9 @@ PY
     CLICK_X=$((WIN_X + WIN_W / 2))
     CLICK_Y=$((WIN_Y + WIN_H - 72))
     require_human_idle "before cliclick injection" || exit 1
-    touch "$NUDGE_STAMP" 2>/dev/null || true
+    reserve_nudge
     if "$CLICLICK_BIN" -r -w 20 "c:${CLICK_X},${CLICK_Y}" "t:${PROMPT_TEXT}" kp:return; then
+      touch "$NUDGE_STAMP" 2>/dev/null || true
       printf '[%s] codex_gui_nudge: sent via cliclick x=%s y=%s\n' "$(date -u +%FT%TZ)" "$CLICK_X" "$CLICK_Y" >>"$LOG_FILE"
       exit 0
     fi
@@ -179,9 +211,8 @@ PY
 fi
 
 require_human_idle "before AppleScript wake" || exit 0
-touch "$NUDGE_STAMP" 2>/dev/null || true
-
-osascript - "$APP_NAME" "$PROMPT_TEXT" "$LOG_FILE" "$LOCK_PY" "$HUMAN_IDLE_CHECK" "$HUMAN_IDLE_SEC" <<'APPLESCRIPT'
+reserve_nudge
+if osascript - "$APP_NAME" "$PROMPT_TEXT" "$LOG_FILE" "$LOCK_PY" "$HUMAN_IDLE_CHECK" "$HUMAN_IDLE_SEC" <<'APPLESCRIPT'
 on run argv
   set appName to item 1 of argv
   set promptText to item 2 of argv
@@ -242,7 +273,7 @@ on run argv
 
   if not my humanIsIdle(pythonBin, idleCheck, idleThreshold) then
     my writeLog(logFile, "ABORT human active or idle state unknown before AppleScript injection")
-    return
+    error "human active before injection" number 1003
   end if
 
   try
@@ -293,3 +324,12 @@ on writeLog(logFile, msg)
   do shell script "printf '[%s] %s\\n' \"$(date -u +%FT%TZ)\" " & quoted form of ("codex_gui_nudge: " & msg) & " >> " & quoted form of logFile
 end writeLog
 APPLESCRIPT
+then
+  touch "$NUDGE_STAMP" 2>/dev/null || true
+  printf '[%s] codex_gui_nudge: sent via AppleScript\n' "$(date -u +%FT%TZ)" >>"$LOG_FILE"
+  exit 0
+else
+  # AppleScript aborts and failures raise an error (non-zero exit): nothing
+  # was delivered, no stamp, so the next wake is not debounced.
+  exit 1
+fi

--- a/tools/codex_gui_nudge.sh
+++ b/tools/codex_gui_nudge.sh
@@ -35,6 +35,26 @@ fi
 # WAIT for an idle window rather than skipping: by the time this script runs
 # the poller has marked the message seen, so skipping would consume it
 # undelivered. Exit 1 on timeout so the caller's failure path applies.
+# One wake per window: with the poller alive, its own nudge AND the webhook
+# receiver's nudge both fire for every mention, and the app answers each
+# (two differently worded reviews 8 s apart, every trigger, 2026-09-01/02).
+# Codex reads the whole recent window per nudge, so a second nudge inside
+# the window adds nothing but a duplicate. The stamp is written only at the
+# point of injection below, so an aborted nudge never suppresses the next.
+NUDGE_STAMP="${IAK_NUDGE_STAMP:-/tmp/codex_gui_nudge.last}"
+NUDGE_DEBOUNCE="${IAK_NUDGE_DEBOUNCE_SEC:-120}"
+if [ -f "$NUDGE_STAMP" ]; then
+    LAST_MTIME=$(stat -c %Y "$NUDGE_STAMP" 2>/dev/null || stat -f %m "$NUDGE_STAMP" 2>/dev/null || echo "")
+    case "$LAST_MTIME" in
+        ''|*[!0-9]*) ;;
+        *)
+            SINCE=$(( $(date +%s) - LAST_MTIME ))
+            if [ "$SINCE" -lt "$NUDGE_DEBOUNCE" ]; then
+                printf '[%s] codex_gui_nudge: debounced (%ss since last nudge, window %ss) - the earlier nudge covers this\n' "$(date -u +%FT%TZ)" "$SINCE" "$NUDGE_DEBOUNCE" >>"$NUDGE_LOG_EARLY"
+                exit 0
+            fi ;;
+    esac
+fi
 if ! "$REPO_ROOT/tools/human-idle-guard.sh" --wait 300; then
     echo "nudge aborted: human continuously active" >&2
     exit 1
@@ -149,6 +169,7 @@ PY
     CLICK_X=$((WIN_X + WIN_W / 2))
     CLICK_Y=$((WIN_Y + WIN_H - 72))
     require_human_idle "before cliclick injection" || exit 1
+    touch "$NUDGE_STAMP" 2>/dev/null || true
     if "$CLICLICK_BIN" -r -w 20 "c:${CLICK_X},${CLICK_Y}" "t:${PROMPT_TEXT}" kp:return; then
       printf '[%s] codex_gui_nudge: sent via cliclick x=%s y=%s\n' "$(date -u +%FT%TZ)" "$CLICK_X" "$CLICK_Y" >>"$LOG_FILE"
       exit 0
@@ -158,6 +179,7 @@ PY
 fi
 
 require_human_idle "before AppleScript wake" || exit 0
+touch "$NUDGE_STAMP" 2>/dev/null || true
 
 osascript - "$APP_NAME" "$PROMPT_TEXT" "$LOG_FILE" "$LOCK_PY" "$HUMAN_IDLE_CHECK" "$HUMAN_IDLE_SEC" <<'APPLESCRIPT'
 on run argv


### PR DESCRIPTION
Follow-up to #87. With the MacBook poller alive again, every mention now produces **two** codex answers seconds apart (23:52:07/23:52:15 on PR 25, 00:03:01/00:03:39 on its follow-up — every trigger since the 23:41 restart): the poller's own nudge (nudge_mode command → `codex_gui_nudge.sh`) and the webhook receiver's nudge both fire, and the app answers each. Codex reads the whole recent window per nudge, so the second wake adds only a duplicate.

**Fix:** `codex_gui_nudge.sh` checks a stamp file (`IAK_NUDGE_STAMP`, default `/tmp/codex_gui_nudge.last`) right after the heartbeat gate — before the up-to-300 s idle wait — and exits 0 as "debounced" when the last injection was less than `IAK_NUDGE_DEBOUNCE_SEC` (120) ago. The stamp is written only at the two injection points (cliclick, AppleScript), so an aborted nudge never suppresses the next.

**Test:** stamp 10 s old → exit 0 with the debounced log line, before any GUI/idle step; an aborted run (poller down) leaves the stamp untouched. Suite 298/298.

@claudeMB the nudge log on the MacBook (`/tmp/codex_gui_nudge.log`) should show pairs of "sent" lines seconds apart before this, and "debounced" lines after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)