### PR TITLE
poller: remember each message as it is handled, durably (#90 item 1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -988,6 +988,8 @@ See `config/team-relay.example.json` for the full config shape. Key sections:
 - `github.event_kinds` - which GitHub events to accept
 - `poller.api_key` - GroupMind API key used by the room poller + chat-reply poller in `iak-mcp-daemon`
 - `poller.notification_file` - where the poller drops new messages for the IDE hooks (default `/tmp/iak-new-messages.txt`); also read by `scripts/session-bootstrap.sh`
+- `poller.history_file` - per-room message history the poller keeps so a mention arrives with its thread: the full parent, the reply chain above it, the asker's previous message, the agent's own last post (default: next to `seen_file`, `<seen_file>-history.json`; 400 messages per room). `poller.fetch_limit` (default 25) is the per-poll window; a reply whose target is older triggers one deeper fetch.
+- **State of play.** Any room message starting with `state:` or `settled:` is a settled fact ("state: card = the benchmark table v2, not hardware"). Every poller records them and, when a batch contains an owner message or a mention, prepends one `STATE OF PLAY` line for that room to the notification file, so agents answer the thread instead of re-deriving it (issue #90). Notification lines stay one physical line per message; the thread rides inside the line.
 - `poller.handle` - the agent's room handle; `scripts/session-bootstrap.sh` uses it to label the bootstrap instructions
 - `mcp.sessions` - list of tmux sessions `wake_all` MCP tool targets
 - `mcp.confirmations` - confirmation registry settings (used by `iak-mcp-daemon`):

--- a/config/codex.desktop.example.json
+++ b/config/codex.desktop.example.json
@@ -33,13 +33,14 @@
       "lattice-qcd"
     ],
     "api_key_file": "/Users/you/.iak/codexmb_api_key.txt",
-  "heartbeat_file": "/tmp/iak-poller.heartbeat",
+    "heartbeat_file": "/tmp/iak-poller.heartbeat",
     "handle": "@CodexMB",
     "interval_sec": 60,
     "nudge_mode": "command",
     "nudge_command": "/ABSOLUTE/PATH/ide-agent-kit/tools/codex_gui_nudge.sh",
     "notification_file": "/tmp/codex-room-notifications.txt",
-    "seen_file": "/tmp/codex-room-seen.txt"
+    "seen_file": "/tmp/codex-room-seen.txt",
+    "history_file": "/tmp/codex-room-history.json"
   },
   "dm_poller": {
     "enabled": true,

--- a/src/common/reply-context.mjs
+++ b/src/common/reply-context.mjs
@@ -35,14 +35,21 @@ export function embeddedTargetOf(raw) {
  * object form when the target is older than the window. Sets m._replyToId
  * and m._replyTarget in place; returns the batch for chaining.
  */
-export function resolveReplyTargets(msgs) {
+export function resolveReplyTargets(msgs, lookup) {
   const byId = new Map(msgs.map((m) => [m.id, m]));
   for (const m of msgs) {
     const replyId = replyIdOf(m.reply_to);
     if (replyId) m._replyToId = replyId;
-    if (replyId && byId.has(replyId)) {
-      const t = byId.get(replyId);
-      m._replyTarget = { from: t.from || t.sender || '?', body: (t.body || '').slice(0, 120) };
+    if (!replyId) continue;
+    let t = byId.get(replyId) || null;
+    // Outside the poll window: ask the caller's history (issue #90). The
+    // room API has no single-message fetch, so this is the only way an
+    // older parent ever resolves.
+    if (!t && typeof lookup === 'function') {
+      try { t = lookup(replyId) || null; } catch { t = null; }
+    }
+    if (t) {
+      m._replyTarget = { from: t.from || t.sender || '?', body: (t.body || '').slice(0, 300), created_at: t.created_at || '' };
     } else {
       const embedded = embeddedTargetOf(m.reply_to);
       if (embedded) m._replyTarget = embedded;

--- a/src/common/room-history.mjs
+++ b/src/common/room-history.mjs
@@ -1,0 +1,190 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+ * Per-room message history for the pollers: the thread an agent needs to
+ * understand a mention, kept locally and persisted across polls.
+ *
+ * Why (issue #90, 1-2 Sep 2026): a mention reached the agent with a
+ * 100-character preview of its parent, or "target not in recent window" when
+ * the parent was older than the 10-message fetch. hermes read "new card" as a
+ * GPU because the messages that had settled "card = benchmark table" were
+ * outside the window. The room API has no single-message fetch and ignores
+ * pagination, but every poller already sees every message as it passes, so
+ * remembering the last few hundred per room gives us: the full parent, the
+ * reply chain above it, the asker's previous message, the agent's own last
+ * post, and the room's settled facts ("state: ..." lines).
+ *
+ * File format: JSON { [room]: [ {id, from, body, created_at, reply_to} ] },
+ * newest last, capped per room. One file per poller (next to seen_file).
+ */
+
+import { readFileSync, writeFileSync, renameSync, mkdirSync } from 'node:fs';
+import { dirname } from 'node:path';
+import { replyIdOf } from './reply-context.mjs';
+
+const BODY_KEEP = 600;
+export const STATE_PREFIX = /^\s*(?:state|settled)\s*:\s*(.+)$/i;
+
+function oneLine(s, n) {
+  return String(s || '').replace(/\s+/g, ' ').trim().slice(0, n);
+}
+
+function hhmm(ts) {
+  const m = /T(\d{2}:\d{2})/.exec(ts || '');
+  return m ? m[1] : '';
+}
+
+export class RoomHistory {
+  constructor(path, { maxPerRoom = 400 } = {}) {
+    this.path = path;
+    this.maxPerRoom = maxPerRoom;
+    this.rooms = {};
+    this.load();
+  }
+
+  load() {
+    try {
+      const data = JSON.parse(readFileSync(this.path, 'utf8'));
+      if (data && typeof data === 'object') this.rooms = data;
+    } catch {
+      this.rooms = {};
+    }
+  }
+
+  save() {
+    try {
+      mkdirSync(dirname(this.path), { recursive: true });
+      const tmp = this.path + '.tmp';
+      writeFileSync(tmp, JSON.stringify(this.rooms));
+      renameSync(tmp, this.path);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /** Add or refresh a fetched batch. Idempotent; keeps newest-last order. */
+  remember(room, msgs) {
+    if (!room || !Array.isArray(msgs) || msgs.length === 0) return;
+    const list = this.rooms[room] || [];
+    const byId = new Map(list.map((m) => [m.id, m]));
+    for (const m of msgs) {
+      if (!m || !m.id) continue;
+      byId.set(m.id, {
+        id: m.id,
+        from: m.from || m.sender || '?',
+        body: oneLine(m.body, BODY_KEEP),
+        created_at: m.created_at || '',
+        reply_to: replyIdOf(m.reply_to),
+        media: [m.image_url && 'image', m.audio_url && 'audio', m.file_url && 'file'].filter(Boolean)
+      });
+    }
+    const merged = [...byId.values()].sort((a, b) => (a.created_at || '').localeCompare(b.created_at || ''));
+    this.rooms[room] = merged.slice(-this.maxPerRoom);
+  }
+
+  get(room, id) {
+    if (!room || !id) return null;
+    return (this.rooms[room] || []).find((m) => m.id === id) || null;
+  }
+
+  /** The sender's latest message strictly before `beforeTs`, excluding ids. */
+  previousFrom(room, sender, beforeTs, exclude = []) {
+    const s = String(sender || '').toLowerCase().replace(/^@/, '');
+    const list = this.rooms[room] || [];
+    for (let i = list.length - 1; i >= 0; i--) {
+      const m = list[i];
+      if (exclude.includes(m.id)) continue;
+      if (beforeTs && (m.created_at || '') >= beforeTs) continue;
+      if (String(m.from || '').toLowerCase().replace(/^@/, '') === s) return m;
+    }
+    return null;
+  }
+
+  /** This agent's own most recent post in the room, if within `withinMs`. */
+  ownRecent(room, selfHandle, nowMs = Date.now(), withinMs = 2 * 3600 * 1000) {
+    const m = this.previousFrom(room, selfHandle, null, []);
+    if (!m) return null;
+    const t = Date.parse(m.created_at || '');
+    if (Number.isFinite(t) && nowMs - t > withinMs) return null;
+    return m;
+  }
+
+  /**
+   * Settled facts: any message whose body starts with "state:" or
+   * "settled:" (case-insensitive), from anyone. Deduplicated on the text,
+   * newest wins, at most `max` entries, oldest first.
+   */
+  stateEntries(room, max = 10) {
+    const out = [];
+    const seenText = new Set();
+    const list = this.rooms[room] || [];
+    for (let i = list.length - 1; i >= 0 && out.length < max; i--) {
+      const m = list[i];
+      const hit = STATE_PREFIX.exec(m.body || '');
+      if (!hit) continue;
+      const text = oneLine(hit[1], 160);
+      const key = text.toLowerCase();
+      if (seenText.has(key)) continue;
+      seenText.add(key);
+      out.push({ from: m.from, created_at: m.created_at, text });
+    }
+    return out.reverse();
+  }
+}
+
+/**
+ * Single-line thread suffix for a message: the parent in full (well, 300
+ * chars) with its author and time, then up to `maxChain` further ancestors
+ * shorter. Falls back to the unresolved marker when neither the batch nor
+ * the history knows the target. Single line by contract: the notification
+ * file is one entry per physical line (see reply-context.mjs).
+ */
+export function threadSuffix(history, room, m, { maxChain = 2, firstLen = 300, chainLen = 150 } = {}) {
+  const replyId = m._replyToId || replyIdOf(m.reply_to);
+  if (!replyId) return '';
+  let parent = history.get(room, replyId);
+  let parts = [];
+  if (parent) {
+    parts.push(` ⤷ in reply to ${parent.from}${hhmm(parent.created_at) ? ' (' + hhmm(parent.created_at) + ')' : ''}: "${oneLine(parent.body, firstLen)}"`);
+  } else if (m._replyTarget) {
+    parts.push(` ⤷ in reply to ${m._replyTarget.from || '?'}: "${oneLine(m._replyTarget.body, firstLen)}"`);
+  } else {
+    return ` ⤷ a reply (target ${replyId} not in recent window)`;
+  }
+  let hops = 0;
+  let cur = parent;
+  while (cur && cur.reply_to && hops < maxChain) {
+    const up = history.get(room, cur.reply_to);
+    if (!up) break;
+    parts.push(` ⤷⤷ ${up.from}: "${oneLine(up.body, chainLen)}"`);
+    cur = up;
+    hops++;
+  }
+  return parts.join('');
+}
+
+/**
+ * The asker's previous message, when it is not already the reply target:
+ * "what did this person say just before" is half the context of a follow-up.
+ */
+export function previousSuffix(history, room, m, { len = 200 } = {}) {
+  const prev = history.previousFrom(room, m.from || m.sender, m.created_at, [m.id, m._replyToId].filter(Boolean));
+  if (!prev) return '';
+  return ` ⤷ ${prev.from}'s previous message${hhmm(prev.created_at) ? ' (' + hhmm(prev.created_at) + ')' : ''}: "${oneLine(prev.body, len)}"`;
+}
+
+/** One line per room per batch: the settled facts, or '' when there are none. */
+export function stateOfPlayLine(history, room, nowIso = new Date().toISOString()) {
+  const entries = history.stateEntries(room);
+  if (entries.length === 0) return '';
+  const body = entries.map((e) => `${e.text} (${String(e.from || '?').replace(/^@/, '')})`).join(' | ');
+  return `[${nowIso.slice(0, 19)}] [${room}] STATE OF PLAY: ${body}`;
+}
+
+/** One line: what this agent itself last said here, so it does not re-answer. */
+export function ownLastPostLine(history, room, selfHandle, nowIso = new Date().toISOString()) {
+  const m = history.ownRecent(room, selfHandle, Date.parse(nowIso));
+  if (!m) return '';
+  return `[${nowIso.slice(0, 19)}] [${room}] YOUR LAST POST HERE (${hhmm(m.created_at)}): "${oneLine(m.body, 200)}"`;
+}

--- a/src/common/seen-ids.mjs
+++ b/src/common/seen-ids.mjs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
-import { readFileSync, writeFileSync } from 'node:fs';
+import { readFileSync, openSync, writeSync, fsyncSync, closeSync, renameSync } from 'node:fs';
 
 /**
  * Shared seen-ID management for all platform pollers.
@@ -15,7 +15,20 @@ export function loadSeenIds(path, maxIds = 2000) {
   }
 }
 
+// Atomic and durable: write a sibling temp file, fsync it, rename over the
+// target. A poller that dies mid-write (or a box that loses power) never
+// leaves a truncated seen-file behind - a truncated one reads as "nothing
+// seen" and replays the whole window on restart, which is exactly what the
+// M5 hermes poller did on 2026-09-01 (issue #90, item 1).
 export function saveSeenIds(path, ids, maxIds = 2000) {
   const arr = [...ids].slice(-maxIds);
-  writeFileSync(path, arr.join('\n') + '\n');
+  const tmp = `${path}.tmp-${process.pid}`;
+  const fd = openSync(tmp, 'w');
+  try {
+    writeSync(fd, arr.join('\n') + '\n');
+    fsyncSync(fd);
+  } finally {
+    closeSync(fd);
+  }
+  renameSync(tmp, path);
 }

--- a/src/team-relay/room-poller.mjs
+++ b/src/team-relay/room-poller.mjs
@@ -305,6 +305,7 @@ export async function startRoomPoller({ rooms, apiKey, handle, interval, config,
       }
       const roomLines = [];
       let roomPriority = false;
+      let roomHeaderWritten = false;
       for (const m of msgs) {
         const mid = m.id;
         if (!mid || seen.has(mid)) continue;
@@ -317,6 +318,18 @@ export async function startRoomPoller({ rooms, apiKey, handle, interval, config,
         const mentionsSelf = (m.body || '').toLowerCase().includes(mentionNeedle);
         if (normalizedSender === ownerHandle) { hasOwnerMessage = true; roomPriority = true; }
         if (mentionsSelf) { hasMention = true; roomPriority = true; }
+        // Context header (settled facts, our own last post) goes to the
+        // notification file once per room, right before the first line that
+        // makes this batch worth a wake - so the reader still sees header
+        // then lines, while every line is on disk before its seen-marker
+        // (#91 per-message durability on top of #92's thread context).
+        if (roomPriority && !roomHeaderWritten) {
+          roomHeaderWritten = true;
+          const sop = stateOfPlayLine(history, room);
+          if (sop) appendNotifications(notifyFile, [sop]);
+          const own = ownLastPostLine(history, room, selfHandle);
+          if (own) appendNotifications(notifyFile, [own]);
+        }
 
         let body = (m.body || '').slice(0, 500);
         // Surface attachments (2026-07-19 lost-screenshot lesson): an
@@ -364,18 +377,9 @@ export async function startRoomPoller({ rooms, apiKey, handle, interval, config,
 
         console.log(`  [${ts.slice(0, 19)}] ${sender} in ${room}: ${body.slice(0, 80)}...`);
       }
-      if (roomLines.length) {
-        // Context header, only when this batch is worth a wake for this room:
-        // the settled facts and what we ourselves said last, so the agent
-        // answers the thread instead of re-verifying or re-answering.
-        if (roomPriority) {
-          const sop = stateOfPlayLine(history, room);
-          if (sop) newMessages.push(sop);
-          const own = ownLastPostLine(history, room, selfHandle);
-          if (own) newMessages.push(own);
-        }
-        newMessages.push(...roomLines);
-      }
+      // Lines and the context header were written per message above;
+      // newMessages only feeds the count/log below.
+      newMessages.push(...roomLines);
     }
 
     saveSeenIds(seenFile, seen);

--- a/src/team-relay/room-poller.mjs
+++ b/src/team-relay/room-poller.mjs
@@ -9,6 +9,7 @@ import { nudgeCommand } from '../utils.mjs';
 import { shouldSuppressNudge } from '../intent.mjs';
 import { resolveSelfHandle } from '../common/handles.mjs';
 import { resolveReplyTargets, replyAnnotation } from '../common/reply-context.mjs';
+import { RoomHistory, threadSuffix, previousSuffix, stateOfPlayLine, ownLastPostLine } from '../common/room-history.mjs';
 
 /**
  * Room Poller — polls GroupMind rooms and notifies IDE agent of new messages.
@@ -171,6 +172,12 @@ export function writeHeartbeat(path) {
 export async function startRoomPoller({ rooms, apiKey, handle, interval, config, sessionOpt }) {
   const seenFile = config?.poller?.seen_file || SEEN_FILE_DEFAULT;
   const heartbeatFile = config?.poller?.heartbeat_file || HEARTBEAT_FILE_DEFAULT;
+  // Per-room message history: resolves reply targets older than the fetch
+  // window, supplies the asker's previous message, the agent's own last post
+  // and the room's "state:" facts (issue #90). One file per poller.
+  const historyFile = config?.poller?.history_file || seenFile.replace(/\.txt$/, '') + '-history.json';
+  const fetchLimit = parsePositiveInt(config?.poller?.fetch_limit, 25);
+  const history = new RoomHistory(historyFile);
   const notifyFile = config?.poller?.notification_file || NOTIFY_FILE_DEFAULT;
   const queuePath = config?.queue?.path || './ide-agent-queue.jsonl';
   const session = sessionOpt || config?.tmux?.ide_session || config?.tmux?.default_session || 'claude';
@@ -221,6 +228,7 @@ export async function startRoomPoller({ rooms, apiKey, handle, interval, config,
   }
   console.log(`  seen file: ${seenFile}`);
   console.log(`  heartbeat: ${heartbeatFile}`);
+  console.log(`  history: ${historyFile} (fetch ${fetchLimit}/poll)`);
   if (dmEnabled) {
     console.log(`  direct messages: enabled`);
     console.log(`    dm handle: ${dmHandle}`);
@@ -274,8 +282,21 @@ export async function startRoomPoller({ rooms, apiKey, handle, interval, config,
     const mentionNeedle = (selfHandle.startsWith('@') ? selfHandle : '@' + selfHandle).toLowerCase();
     const newMessages = [];
     for (const room of rooms) {
-      const msgs = await fetchRoomMessages(room, apiKey);
-      resolveReplyTargets(msgs);
+      let msgs = await fetchRoomMessages(room, apiKey, fetchLimit);
+      history.remember(room, msgs);
+      const lookup = (id) => history.get(room, id);
+      resolveReplyTargets(msgs, lookup);
+      // A reply whose target is older than both the window and our history:
+      // one deeper fetch per room per poll, then resolve again.
+      if (msgs.some((m) => m._replyToId && !m._replyTarget && !seen.has(m.id))) {
+        const deeper = await fetchRoomMessages(room, apiKey, 100);
+        if (deeper.length) {
+          history.remember(room, deeper);
+          resolveReplyTargets(msgs, lookup);
+        }
+      }
+      const roomLines = [];
+      let roomPriority = false;
       for (const m of msgs) {
         const mid = m.id;
         if (!mid || seen.has(mid)) continue;
@@ -285,8 +306,9 @@ export async function startRoomPoller({ rooms, apiKey, handle, interval, config,
         const normalizedSender = normalizeHandle(sender);
         // Skip own messages
         if (normalizedSender === selfHandle) continue;
-        if (normalizedSender === ownerHandle) hasOwnerMessage = true;
-        if ((m.body || '').toLowerCase().includes(mentionNeedle)) hasMention = true;
+        const mentionsSelf = (m.body || '').toLowerCase().includes(mentionNeedle);
+        if (normalizedSender === ownerHandle) { hasOwnerMessage = true; roomPriority = true; }
+        if (mentionsSelf) { hasMention = true; roomPriority = true; }
 
         let body = (m.body || '').slice(0, 500);
         // Surface attachments (2026-07-19 lost-screenshot lesson): an
@@ -318,17 +340,35 @@ export async function startRoomPoller({ rooms, apiKey, handle, interval, config,
         const event = await enrichEvent(rawEvent, config);
         appendFileSync(queuePath, JSON.stringify(event) + '\n');
 
-        // Collect for notification file
-        const line = `[${ts.slice(0, 19)}] [${room}] ${sender}: ${body.replace(/\n/g, ' ').slice(0, 200)}`
-          + replyAnnotation(m._replyToId, m._replyTarget);
-        newMessages.push(line);
+        // Collect for notification file. ONE physical line per message
+        // (readers split on \n and count lines), so the thread rides inside
+        // the line: parent in full, chain above it, and for owner messages
+        // or mentions the asker's previous message (issue #90).
+        const thread = threadSuffix(history, room, m) || replyAnnotation(m._replyToId, m._replyTarget);
+        const prev = (normalizedSender === ownerHandle || mentionsSelf) ? previousSuffix(history, room, m) : '';
+        const line = `[${ts.slice(0, 19)}] [${room}] ${sender}: ${body.replace(/\n/g, ' ').slice(0, 400)}`
+          + thread + prev;
+        roomLines.push(line);
         newCount++;
 
         console.log(`  [${ts.slice(0, 19)}] ${sender} in ${room}: ${body.slice(0, 80)}...`);
       }
+      if (roomLines.length) {
+        // Context header, only when this batch is worth a wake for this room:
+        // the settled facts and what we ourselves said last, so the agent
+        // answers the thread instead of re-verifying or re-answering.
+        if (roomPriority) {
+          const sop = stateOfPlayLine(history, room);
+          if (sop) newMessages.push(sop);
+          const own = ownLastPostLine(history, room, selfHandle);
+          if (own) newMessages.push(own);
+        }
+        newMessages.push(...roomLines);
+      }
     }
 
     saveSeenIds(seenFile, seen);
+    history.save();
 
     if (newCount > 0) {
       // Primary: write to notification file (always works)

--- a/src/team-relay/room-poller.mjs
+++ b/src/team-relay/room-poller.mjs
@@ -169,6 +169,20 @@ export function writeHeartbeat(path) {
   }
 }
 
+/**
+ * First-run seed for one room: every current message is marked seen (do not
+ * answer the backlog) AND stored in the history (do not lose the thread when
+ * the next poll replies to one of them). Exported for the regression test.
+ */
+export function seedRoom({ seen, history, room, msgs }) {
+  let added = 0;
+  for (const m of msgs || []) {
+    if (m && m.id && !seen.has(m.id)) { seen.add(m.id); added++; }
+  }
+  if (history && typeof history.remember === 'function') history.remember(room, msgs || []);
+  return added;
+}
+
 export async function startRoomPoller({ rooms, apiKey, handle, interval, config, sessionOpt }) {
   const seenFile = config?.poller?.seen_file || SEEN_FILE_DEFAULT;
   const heartbeatFile = config?.poller?.heartbeat_file || HEARTBEAT_FILE_DEFAULT;
@@ -243,16 +257,17 @@ export async function startRoomPoller({ rooms, apiKey, handle, interval, config,
   const seen = loadSeenIds(seenFile);
   const dmSeen = dmEnabled ? loadSeenIds(dmSeenFile) : new Set();
 
-  // Seed: mark current messages as seen on first run
+  // Seed: mark current messages as seen on first run, and REMEMBER them, so
+  // a reply to one of these on the very next poll still gets its parent
+  // (codexmb, PR #92 review: seeding without history lost first-run context).
   if (seen.size === 0) {
     console.log(`  seeding seen IDs from current messages...`);
     for (const room of rooms) {
       const msgs = await fetchRoomMessages(room, apiKey, 50);
-      for (const m of msgs) {
-        if (m.id) seen.add(m.id);
-      }
+      seedRoom({ seen, history, room, msgs });
     }
     saveSeenIds(seenFile, seen);
+    history.save();
     console.log(`  seeded ${seen.size} IDs`);
   }
 

--- a/src/team-relay/room-poller.mjs
+++ b/src/team-relay/room-poller.mjs
@@ -1,4 +1,5 @@
 import { NOTIFY_FILE_DEFAULT, SEEN_FILE_DEFAULT, QUEUE_PATH_DEFAULT } from '../common/constants.mjs';
+import { loadSeenIds, saveSeenIds as saveSeenIdsShared } from '../common/seen-ids.mjs';
 import { enrichEvent } from './enrichment.mjs';
 // SPDX-License-Identifier: AGPL-3.0-only
 
@@ -30,19 +31,11 @@ import { RoomHistory, threadSuffix, previousSuffix, stateOfPlayLine, ownLastPost
 
 
 
-function loadSeenIds(path) {
-  try {
-    return new Set(readFileSync(path, 'utf8').split('\n').filter(Boolean));
-  } catch {
-    return new Set();
-  }
-}
-
-function saveSeenIds(path, ids) {
-  // Keep last 1000 IDs to prevent unbounded growth
-  const arr = [...ids].slice(-1000);
-  writeFileSync(path, arr.join('\n') + '\n');
-}
+// Seen-state comes from the shared module (atomic + fsynced, issue #90).
+// The marker is written after EACH handled message below, never once per
+// batch: a batch can hold a task that runs for an hour, and a restart inside
+// it replayed a whole day on the M5 (2026-09-01).
+const saveSeenIds = (path, ids) => saveSeenIdsShared(path, ids, 1000);
 
 const DM_SEEN_FILE_DEFAULT = '/tmp/iak-dm-seen-ids.txt';
 
@@ -365,6 +358,9 @@ export async function startRoomPoller({ rooms, apiKey, handle, interval, config,
           + thread + prev;
         roomLines.push(line);
         newCount++;
+        // Handled = queued + notified; only then is it safe to remember it.
+        appendNotifications(notifyFile, [line]);
+        saveSeenIds(seenFile, seen);
 
         console.log(`  [${ts.slice(0, 19)}] ${sender} in ${room}: ${body.slice(0, 80)}...`);
       }
@@ -386,8 +382,7 @@ export async function startRoomPoller({ rooms, apiKey, handle, interval, config,
     history.save();
 
     if (newCount > 0) {
-      // Primary: write to notification file (always works)
-      appendNotifications(notifyFile, newMessages);
+      // Notification lines were appended per message above.
       // Owner messages always qualify; agent @-mentions qualify unless the user
       // is in emergency-only mode (that mode exists to mute agent chatter).
       const mentionQualifies = hasMention && !hasOwnerMessage ? !(await shouldSuppressNudge(config)) : hasMention;
@@ -444,6 +439,8 @@ export async function startRoomPoller({ rooms, apiKey, handle, interval, config,
         const line = `[${ts.slice(0, 19)}] [dm] ${sender} -> ${recipient}: ${body.replace(/\n/g, ' ').slice(0, 200)}`;
         newMessages.push(line);
         newCount++;
+        appendNotifications(dmNotifyFile, [line]);
+        saveSeenIds(dmSeenFile, dmSeen);
 
         console.log(`  [${ts.slice(0, 19)}] ${sender} DM -> ${recipient}: ${body.slice(0, 80)}...`);
       }
@@ -451,7 +448,7 @@ export async function startRoomPoller({ rooms, apiKey, handle, interval, config,
       saveSeenIds(dmSeenFile, dmSeen);
 
       if (newCount > 0) {
-        appendNotifications(dmNotifyFile, newMessages);
+        // Notification lines were appended per message above.
         // DMs are addressed to this agent, so they inherently qualify; owner DMs
         // bypass emergency-only, other senders respect it. Cooldown still applies.
         const dmQualifies = hasOwnerMessage || !(await shouldSuppressNudge(config));

--- a/test/room-history.test.mjs
+++ b/test/room-history.test.mjs
@@ -7,6 +7,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { RoomHistory, threadSuffix, previousSuffix, stateOfPlayLine, ownLastPostLine } from '../src/common/room-history.mjs';
 import { resolveReplyTargets } from '../src/common/reply-context.mjs';
+import { seedRoom } from '../src/team-relay/room-poller.mjs';
 
 const R = 'thinkoff-development';
 function msg(id, from, body, created_at, reply_to) {
@@ -108,5 +109,25 @@ describe('room-history (issue #90: the thread, not the window)', () => {
     assert.ok(line.includes('YOUR LAST POST HERE (21:36): "PR 24 is ready to merge"'), line);
     assert.equal(ownLastPostLine(h, R, '@claudemb', '2026-09-02T09:00:00Z'), '', 'older than two hours');
     assert.equal(ownLastPostLine(h, R, '@nobody', '2026-09-01T21:50:00Z'), '');
+  });
+});
+
+
+describe('first-run seed keeps the thread (codexmb, PR #92)', () => {
+  it('seeded messages are both seen and remembered, so a reply to one resolves on the next poll', () => {
+    const h = fresh();
+    const seen = new Set();
+    const seeded = [
+      msg('old1', '@claudeMB', 'Card v2 for your review', '2026-09-01T15:46:19Z'),
+      msg('old2', 'petrus', 'But these people get 15 tps?', '2026-09-01T18:53:35Z')
+    ];
+    assert.equal(seedRoom({ seen, history: h, room: R, msgs: seeded }), 2);
+    assert.ok(seen.has('old1') && seen.has('old2'));
+    assert.equal(seedRoom({ seen, history: h, room: R, msgs: seeded }), 0, 'idempotent');
+    // next poll: only the reply is in the window
+    const batch = [msg('new', 'petrus', 'you have a new card which I cant post', '2026-09-01T19:04:46Z', 'old1')];
+    resolveReplyTargets(batch, (id) => h.get(R, id));
+    assert.equal(batch[0]._replyTarget.from, '@claudeMB');
+    assert.ok(threadSuffix(h, R, batch[0]).includes('Card v2 for your review'));
   });
 });

--- a/test/room-history.test.mjs
+++ b/test/room-history.test.mjs
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { RoomHistory, threadSuffix, previousSuffix, stateOfPlayLine, ownLastPostLine } from '../src/common/room-history.mjs';
+import { resolveReplyTargets } from '../src/common/reply-context.mjs';
+
+const R = 'thinkoff-development';
+function msg(id, from, body, created_at, reply_to) {
+  return { id, from, body, created_at, reply_to };
+}
+function fresh() {
+  return new RoomHistory(join(mkdtempSync(join(tmpdir(), 'iak-hist-')), 'h.json'), { maxPerRoom: 5 });
+}
+
+describe('room-history (issue #90: the thread, not the window)', () => {
+  it('remembers across polls, persists, dedupes by id and caps per room', () => {
+    const h = fresh();
+    h.remember(R, [msg('a', 'petrus', 'one', '2026-09-01T19:00:00Z')]);
+    h.remember(R, [msg('a', 'petrus', 'one edited', '2026-09-01T19:00:00Z'), msg('b', '@x', 'two', '2026-09-01T19:01:00Z')]);
+    assert.equal(h.get(R, 'a').body, 'one edited');
+    assert.ok(h.save());
+    const again = new RoomHistory(h.path);
+    assert.equal(again.get(R, 'b').from, '@x');
+    for (let i = 0; i < 10; i++) h.remember(R, [msg('m' + i, '@x', 'n' + i, `2026-09-01T20:0${i}:00Z`.slice(0, 20))]);
+    assert.equal(h.rooms[R].length, 5);
+    assert.equal(h.get(R, 'a'), null, 'oldest evicted');
+  });
+
+  it('resolves a reply target older than the fetch window via lookup', () => {
+    const h = fresh();
+    // poll 1: the parent passes by
+    h.remember(R, [msg('card', '@claudeMB', 'Card v2 for your review, nothing published by me. Changes: M5 solo column re-measured...', '2026-09-01T15:46:19Z')]);
+    // poll 2: only the reply is in the window
+    const batch = [msg('reply', 'petrus', 'Yeah you have a new card which I cant post', '2026-09-01T19:04:46Z', 'card')];
+    resolveReplyTargets(batch, (id) => h.get(R, id));
+    assert.equal(batch[0]._replyTarget.from, '@claudeMB');
+    assert.ok(batch[0]._replyTarget.body.startsWith('Card v2 for your review'));
+    const suffix = threadSuffix(h, R, batch[0]);
+    assert.ok(suffix.includes('in reply to @claudeMB (15:46)'), suffix);
+    assert.ok(suffix.includes('Card v2 for your review, nothing published by me'), suffix);
+    assert.ok(!suffix.includes('\n'), 'single line by contract');
+  });
+
+  it('walks the chain above the parent, bounded, and stays single-line', () => {
+    const h = fresh();
+    h.remember(R, [
+      msg('g', 'petrus', 'grand\nparent', '2026-09-01T10:00:00Z'),
+      msg('p', '@x', 'parent', '2026-09-01T10:01:00Z', 'g'),
+      msg('c', 'petrus', 'child', '2026-09-01T10:02:00Z', 'p')
+    ]);
+    const s = threadSuffix(h, R, h.get(R, 'c') && { id: 'c', from: 'petrus', reply_to: 'p', _replyToId: 'p' });
+    assert.ok(s.includes('in reply to @x (10:01): "parent"'), s);
+    assert.ok(s.includes('⤷⤷ petrus: "grand parent"'), s);
+    assert.ok(!s.includes('\n'));
+  });
+
+  it('falls back to the unresolved marker when nobody knows the target', () => {
+    const h = fresh();
+    const s = threadSuffix(h, R, { id: 'z', reply_to: 'ghost', _replyToId: 'ghost' });
+    assert.ok(s.includes('target ghost not in recent window'), s);
+  });
+
+  it("gives the asker's previous message, not the reply target, and skips self", () => {
+    const h = fresh();
+    h.remember(R, [
+      msg('p1', 'petrus', 'I found only these what more shall i order', '2026-09-01T20:56:03Z'),
+      msg('a1', '@claudeMB', 'Found on the table...', '2026-09-01T20:59:15Z'),
+      msg('p2', 'petrus', 'I reorder this one?', '2026-09-01T21:14:53Z')
+    ]);
+    const m = { id: 'p2', from: 'petrus', created_at: '2026-09-01T21:14:53Z' };
+    const s = previousSuffix(h, R, m);
+    assert.ok(s.includes("petrus's previous message (20:56)"), s);
+    assert.ok(s.includes('what more shall i order'), s);
+    assert.equal(previousSuffix(h, R, { id: 'p1', from: 'petrus', created_at: '2026-09-01T20:56:03Z' }), '');
+  });
+
+  it('collects state: lines, dedupes, caps, renders one line', () => {
+    const h = fresh();
+    h.remember(R, [
+      msg('s1', '@claudeMB', 'state: "card" means the benchmark table v2, not hardware', '2026-09-01T19:37:00Z'),
+      msg('n1', 'hermes', 'Got it, I cannot see the card either', '2026-09-01T19:38:00Z'),
+      msg('s2', '@claudemm', 'Settled: BIOS carve fix waits for Petrus in Helsinki', '2026-09-01T19:40:00Z'),
+      msg('s3', 'petrus', 'state: "card" means the benchmark table v2, not hardware', '2026-09-01T19:41:00Z')
+    ]);
+    const e = h.stateEntries(R);
+    assert.equal(e.length, 2, 'duplicate text collapsed');
+    // newest occurrence of a duplicate wins, entries are oldest-first
+    assert.deepEqual(e.map((x) => x.text), [
+      'BIOS carve fix waits for Petrus in Helsinki',
+      '"card" means the benchmark table v2, not hardware'
+    ]);
+    assert.equal(e[1].from, 'petrus', 'the newest sender of the duplicated fact');
+    const line = stateOfPlayLine(h, R, '2026-09-01T20:00:00Z');
+    assert.ok(line.startsWith(`[2026-09-01T20:00:00] [${R}] STATE OF PLAY: `), line);
+    assert.ok(line.includes('BIOS carve fix waits for Petrus in Helsinki (claudemm)'), line);
+    assert.ok(!line.includes('\n'));
+    assert.equal(stateOfPlayLine(fresh(), R), '');
+  });
+
+  it("renders the agent's own last post when recent, nothing when stale or absent", () => {
+    const h = fresh();
+    h.remember(R, [msg('o1', '@claudeMB', 'PR 24 is ready to merge', '2026-09-01T21:36:24Z')]);
+    const line = ownLastPostLine(h, R, '@claudemb', '2026-09-01T21:50:00Z');
+    assert.ok(line.includes('YOUR LAST POST HERE (21:36): "PR 24 is ready to merge"'), line);
+    assert.equal(ownLastPostLine(h, R, '@claudemb', '2026-09-02T09:00:00Z'), '', 'older than two hours');
+    assert.equal(ownLastPostLine(h, R, '@nobody', '2026-09-01T21:50:00Z'), '');
+  });
+});

--- a/test/seen-state.test.mjs
+++ b/test/seen-state.test.mjs
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Issue #90 item 1: seen-state is durable and written per handled message.
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, readdirSync, chmodSync, mkdirSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { saveSeenIds, loadSeenIds } from '../src/common/seen-ids.mjs';
+import { startRoomPoller } from '../src/team-relay/room-poller.mjs';
+
+test('saveSeenIds writes atomically (no temp file left, content complete, round-trips)', () => {
+  const dir = mkdtempSync(path.join(tmpdir(), 'iak-seen-'));
+  try {
+    const f = path.join(dir, 'seen');
+    saveSeenIds(f, new Set(['a', 'b', 'c']));
+    assert.deepEqual([...loadSeenIds(f)], ['a', 'b', 'c']);
+    assert.deepEqual(readdirSync(dir), ['seen'], 'temp file renamed away');
+    saveSeenIds(f, new Set(Array.from({ length: 2500 }, (_, i) => `id${i}`)), 2000);
+    assert.equal(loadSeenIds(f).size, 2000, 'capped at maxIds');
+  } finally { rmSync(dir, { recursive: true, force: true }); }
+});
+
+test('the live poller remembers each message as it is handled, not once per batch', async () => {
+  // Second message has a numeric body, which the poller cannot handle and
+  // throws on. Before #90 the batch-level save never ran, so a restart
+  // re-delivered message 1 (and every message before it). Now message 1 is
+  // in the seen-file and its notification line is on disk before the crash.
+  const dir = mkdtempSync(path.join(tmpdir(), 'iak-seenlive-'));
+  const savedPath = process.env.PATH;
+  let timers;
+  try {
+    const stubDir = path.join(dir, 'bin'); mkdirSync(stubDir);
+    const stub = path.join(stubDir, 'curl');
+    // first call (seeding, limit=50) must return nothing so the ids are unseen;
+    // later calls return the two messages
+    writeFileSync(stub, `#!/bin/sh
+case "$*" in *limit=50*) echo "[]";; *) echo '[{"id":"m1","from":"petrus","body":"hello one","created_at":"2026-09-02T00:00:01Z"},{"id":"m2","from":"petrus","body":123,"created_at":"2026-09-02T00:00:02Z"}]';; esac
+`);
+    chmodSync(stub, 0o755);
+    process.env.PATH = `${stubDir}:${savedPath}`;
+    const seenFile = path.join(dir, 'seen'); const notifyFile = path.join(dir, 'notify');
+    let threw = false;
+    try {
+      timers = await startRoomPoller({
+        rooms: ['r'], apiKey: 'k', handle: '@t', interval: 3600,
+        config: { poller: { seen_file: seenFile, notification_file: notifyFile, heartbeat_file: path.join(dir, 'hb'), nudge_mode: 'none' }, queue: { path: path.join(dir, 'q.jsonl') } }
+      });
+    } catch (e) { threw = true; }
+    assert.ok(threw, 'the numeric body makes the first poll throw (the test premise)');
+    assert.ok(existsSync(seenFile), 'seen-file exists after the crash');
+    const seen = loadSeenIds(seenFile);
+    assert.ok(seen.has('m1'), 'message 1 was persisted before message 2 crashed the batch');
+    assert.match(readFileSync(notifyFile, 'utf8'), /petrus: hello one/, 'message 1 notification line is on disk');
+  } finally {
+    if (timers?.roomTimer) clearInterval(timers.roomTimer);
+    if (timers?.dmTimer) clearInterval(timers.dmTimer);
+    process.env.PATH = savedPath;
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/test/seen-state.test.mjs
+++ b/test/seen-state.test.mjs
@@ -58,3 +58,39 @@ case "$*" in *limit=50*) echo "[]";; *) echo '[{"id":"m1","from":"petrus","body"
     rmSync(dir, { recursive: true, force: true });
   }
 });
+
+test('with #92 thread context: the state-of-play header lands once, before the first priority line, and no line is written twice', async () => {
+  const dir = mkdtempSync(path.join(tmpdir(), 'iak-header-'));
+  const savedPath = process.env.PATH;
+  let timers;
+  try {
+    const stubDir = path.join(dir, 'bin'); mkdirSync(stubDir);
+    const stub = path.join(stubDir, 'curl');
+    writeFileSync(stub, `#!/bin/sh
+case "$*" in *limit=50*) echo "[]";; *) echo '[{"id":"s1","from":"@claudeMB","body":"state: the card is the benchmark table v2, not hardware","created_at":"2026-09-02T00:00:01Z"},{"id":"o1","from":"petrus","body":"claudemm what is the card","created_at":"2026-09-02T00:00:02Z"}]';; esac
+`);
+    chmodSync(stub, 0o755);
+    process.env.PATH = `${stubDir}:${savedPath}`;
+    const notifyFile = path.join(dir, 'notify');
+    const origLog = console.log; console.log = () => {};
+    try {
+      timers = await startRoomPoller({
+        rooms: ['r'], apiKey: 'k', handle: '@claudemm', interval: 3600,
+        config: { poller: { seen_file: path.join(dir, 'seen'), notification_file: notifyFile, heartbeat_file: path.join(dir, 'hb'), nudge_mode: 'none', owner: 'petrus' }, queue: { path: path.join(dir, 'q.jsonl') } }
+      });
+    } finally { console.log = origLog; }
+    const lines = readFileSync(notifyFile, 'utf8').split('\n').filter(Boolean);
+    const stateIdx = lines.findIndex((l) => /state/i.test(l) && /benchmark table v2/.test(l) && !/@claudeMB:/.test(l));
+    const ownerIdx = lines.findIndex((l) => /petrus: claudemm what is the card/.test(l));
+    assert.ok(stateIdx >= 0, `state-of-play header present: ${lines.join(' | ')}`);
+    assert.ok(ownerIdx >= 0, 'owner line present');
+    assert.ok(stateIdx < ownerIdx, 'header precedes the first priority line');
+    assert.equal(lines.filter((l) => /petrus: claudemm what is the card/.test(l)).length, 1, 'owner line written exactly once');
+    assert.equal(lines.filter((l) => /@claudeMB: state:/.test(l)).length, 1, 'state message line written exactly once');
+  } finally {
+    if (timers?.roomTimer) clearInterval(timers.roomTimer);
+    if (timers?.dmTimer) clearInterval(timers.dmTimer);
+    process.env.PATH = savedPath;
+    rmSync(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
#90 item 1 (split agreed with claudeMB in the room).

**Problem:** the team-relay poller saved seen-ids once per batch; a batch can hold a task that runs for an hour, so a restart inside it replayed the whole window (the M5 hermes poller did exactly that on 2026-09-01 — state stale since 31 Aug). A plain `writeFileSync` can also leave a truncated file on crash/power loss, which reads as "nothing seen" and replays everything.

**Change:**
- `src/common/seen-ids.mjs`: `saveSeenIds` writes a temp file, fsyncs, renames over the target (atomic, durable).
- `src/team-relay/room-poller.mjs`: uses the shared module (its private copies are gone); the notification line and the seen-marker are written right after each handled message, in both the room and DM loops. The post-loop nudge/gating logic is unchanged; the post-loop batch append is removed (lines are already on disk).

**Tests** (`test/seen-state.test.mjs`): atomic round-trip + cap; a live `startRoomPoller` run against a stub `curl` where the second message has a numeric body and crashes the batch — message 1 is in the seen-file and its notification line on disk before the crash. Positive control: the same test fails on the previous poller. Suite 299/299.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
